### PR TITLE
[codex] Align workspace baseline and real-mode fallback contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,12 @@ dev-wiki/       # 개발 중 작업 노트와 실험 기록, gitignored
 ## Architecture Note
 
 - 이 레포는 웹 서비스 중심 레포입니다.
+- 이 레포의 중심 제품 모델은 markdown-native personal workspace 입니다.
 - MCP 서버 구현은 포함하지 않습니다.
 - MCP 기반 클라이언트는 WAS 공개 API를 소비하는 외부 소비자로 취급합니다.
 - StrataWiki 같은 knowledge backend와 그 DB schema/migration ownership은 이 레포에 포함하지 않습니다.
+- Jobs-Wiki는 recruiting domain semantics, source normalization, proposal generation, workspace UX 를 소유합니다.
+- StrataWiki는 canonical shared `Fact`/`Interpretation` storage 와 runtime governance 를 소유합니다.
 - Ingestion은 WAS와 분리된 별도 계층으로 다룹니다.
 - WAS는 ingestion을 직접 수행하지 않습니다.
 - WAS가 할 수 있는 것은 필요 시 ingestion job을 좁은 경계로 요청하는 것뿐입니다.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Jobs-Wiki
 
-현재 구현 기준은 report-first MVP입니다. frontend는 WAS만 호출하고, 기본 리포트와 공고 상세, Ask, Calendar 흐름을 우선합니다.
+현재 구현 기준은 `workspace-first PKM MVP`입니다.
+`report`, `opportunity`, `ask`, `calendar`는 workspace 안의 핵심 projection/flow로 취급합니다.
+루트 README보다 더 구체적인 기준선이 필요하면 `docs/README.md`와 `docs/product/mvp-requirements-baseline.md`를 우선합니다.
 
 핵심 문서 진입점:
 
@@ -33,6 +35,8 @@
 
    - `/onboarding`
    - `/review`
+   - `/workspace`
+   - `/documents/:documentId`
    - `/report`
    - `/opportunities/:opportunityId`
    - `/ask`
@@ -137,7 +141,7 @@ dev-wiki/       # 개발 중 작업 노트와 실험 기록, gitignored
 - Ingestion은 WAS와 분리된 별도 계층으로 다룹니다.
 - WAS는 ingestion을 직접 수행하지 않습니다.
 - WAS가 할 수 있는 것은 필요 시 ingestion job을 좁은 경계로 요청하는 것뿐입니다.
-- StrataWiki integration 은 현재 HTTP/REST 우선, wrapper rollback path 를 함께 유지하는 dual-mode 입니다.
+- StrataWiki integration 은 현재 HTTP-first baseline 이고, SQL read fallback 은 deprecated compatibility path 로 남아 있습니다.
 - resource-specific HTTP endpoint 가 있는 경우 Jobs-Wiki 는 generic tool bridge 보다 해당 endpoint 를 우선 사용합니다.
 
 ## Docs Policy

--- a/apps/ingestion/README.md
+++ b/apps/ingestion/README.md
@@ -156,7 +156,7 @@ npm start -- --source worknet --dry-run
   - `validate_domain_proposal_batch` / `ingest_domain_proposal_batch` CLI rollback path 에 필요
   - `JOBS_WIKI_STRATAWIKI_ACTIVE_DOMAIN_PACKS`
     - optional active pack mapping
-    - example: `recruiting=2026-04-18`
+    - example: `recruiting=2026-04-22`
 
 ## Notes
 

--- a/apps/ingestion/test/map-worknet-payloads-to-proposal-batches.test.js
+++ b/apps/ingestion/test/map-worknet-payloads-to-proposal-batches.test.js
@@ -15,7 +15,7 @@ function createNoopLogger() {
 test("mapWorknetPayloadsToProposalBatches creates proposal batches and summary counts", () => {
   const result = mapWorknetPayloadsToProposalBatches({
     env: {
-      stratawikiRecruitingPackVersion: "2026-04-18",
+      stratawikiRecruitingPackVersion: "2026-04-22",
     },
     logger: createNoopLogger(),
     runId: "map-run-1",
@@ -69,5 +69,5 @@ test("mapWorknetPayloadsToProposalBatches creates proposal batches and summary c
   assert.equal(result.batchReports[0]?.sourceId, "EMP-1")
   assert.equal(result.batchReports[0]?.factProposalCount, 3)
   assert.equal(result.proposalBatches[0]?.batch.domain, "recruiting")
-  assert.equal(result.proposalBatches[0]?.batch.pack_version, "2026-04-18")
+  assert.equal(result.proposalBatches[0]?.batch.pack_version, "2026-04-22")
 })

--- a/apps/ingestion/test/retry.test.js
+++ b/apps/ingestion/test/retry.test.js
@@ -69,7 +69,7 @@ test("buildFailureRunSummary preserves retry and orchestration context", () => {
       stratawikiConfigured: true,
       stratawikiCliWrapper: "/tmp/wrapper",
       stratawikiDomainPackPaths: ["/tmp/recruiting-pack.json"],
-      stratawikiActiveDomainPacks: { recruiting: "2026-04-18" },
+      stratawikiActiveDomainPacks: { recruiting: "2026-04-22" },
     },
     error,
   })

--- a/apps/ingestion/test/run-summary-store.test.js
+++ b/apps/ingestion/test/run-summary-store.test.js
@@ -44,7 +44,7 @@ test("buildFailureRunSummary captures the failure envelope without secrets", () 
       stratawikiConfigured: true,
       stratawikiCliWrapper: "/tmp/wrapper",
       stratawikiDomainPackPaths: ["/tmp/recruiting-pack.json"],
-      stratawikiActiveDomainPacks: { recruiting: "2026-04-18" },
+      stratawikiActiveDomainPacks: { recruiting: "2026-04-22" },
     },
     error: new Error("runtime unavailable"),
   })

--- a/apps/ingestion/test/run-worknet-ingestion.test.js
+++ b/apps/ingestion/test/run-worknet-ingestion.test.js
@@ -64,9 +64,9 @@ test("runWorknetIngestion validates proposal batches in dry-run mode", async () 
       stratawikiCliWrapper: "/tmp/fake-wrapper",
       stratawikiDomainPackPaths: ["/tmp/recruiting-pack.json"],
       stratawikiActiveDomainPacks: {
-        recruiting: "2026-04-18",
+        recruiting: "2026-04-22",
       },
-      stratawikiRecruitingPackVersion: "2026-04-18",
+      stratawikiRecruitingPackVersion: "2026-04-22",
     },
     logger: createNoopLogger(),
     dryRun: true,
@@ -140,9 +140,9 @@ test("runWorknetIngestion ingests validated proposal batches in apply mode", asy
       stratawikiCliWrapper: "/tmp/fake-wrapper",
       stratawikiDomainPackPaths: ["/tmp/recruiting-pack.json"],
       stratawikiActiveDomainPacks: {
-        recruiting: "2026-04-18",
+        recruiting: "2026-04-22",
       },
-      stratawikiRecruitingPackVersion: "2026-04-18",
+      stratawikiRecruitingPackVersion: "2026-04-22",
     },
     logger: createNoopLogger(),
     dryRun: false,

--- a/apps/ingestion/test/stratawiki-cli-client.test.js
+++ b/apps/ingestion/test/stratawiki-cli-client.test.js
@@ -141,9 +141,9 @@ echo '{"ok":false}'
       stratawikiCliWrapper: wrapperPath,
       stratawikiDomainPackPathsRaw: packPath,
       stratawikiDomainPackPaths: [packPath],
-      stratawikiActiveDomainPacksRaw: "recruiting=2026-04-18",
+      stratawikiActiveDomainPacksRaw: "recruiting=2026-04-22",
       stratawikiActiveDomainPacks: {
-        recruiting: "2026-04-18",
+        recruiting: "2026-04-22",
       },
       stratawikiConfigured: true,
     },
@@ -164,7 +164,7 @@ echo '{"ok":false}'
   assert.equal(response.tool, "validate_domain_proposal_batch")
   assert.equal(response.args.batch.batch_id, "batch-1")
   assert.equal(response.domainPackPath, packPath)
-  assert.equal(response.activePack, "recruiting=2026-04-18")
+  assert.equal(response.activePack, "recruiting=2026-04-22")
 
   const personalResponse = await client.callTool("query_personal_knowledge", {
     question: "How should I apply?",

--- a/apps/was/README.md
+++ b/apps/was/README.md
@@ -29,7 +29,9 @@
 현재 real mode 는 아래 세 경계를 조합합니다.
 
 - read authority
-  - StrataWiki canonical read DB 를 직접 읽는 read-backed projection path
+  - `JOBS_WIKI_READ_AUTHORITY_MODE=sql|http`
+  - current default 는 StrataWiki consumer-shaped HTTP read path
+  - `sql` 은 parity/fallback 용 deprecated path
 - ask workspace / personal document facade
   - read-backed baseline answer
   - 조건이 맞을 때만 personal-aware upgrade
@@ -79,13 +81,18 @@ npm start
 - `WAS_DATA_MODE=mock|real`
 - `WAS_LOG_LEVEL`
 - `STRATAWIKI_READ_DATABASE_URL`
+  - `sql` read authority mode 에서만 사용
   - 기본값: `postgresql://stratawiki:stratawiki@localhost:5432/stratawiki_jobswiki`
 - `STRATAWIKI_READ_PSQL_BIN`
+  - `sql` read authority mode 에서만 사용
   - 기본값: `psql`
 - `STRATAWIKI_READ_DOMAIN`
   - 기본값: `recruiting`
 - `STRATAWIKI_READ_SCOPE`
   - 기본값: `shared`
+- `JOBS_WIKI_READ_AUTHORITY_MODE`
+  - `sql|http`
+  - 기본값: `http`
 - `STRATAWIKI_INTEGRATION_MODE`
   - current baseline 은 `http`
   - legacy `auto|wrapper` compatibility path 는 운영 기준선으로 설명하지 않습니다
@@ -171,7 +178,14 @@ GET /health
 `WAS_DATA_MODE=real` 에서는 아래처럼 동작합니다.
 
 - `workspace`, `workspace/summary`, `opportunities`, `calendar`
-  - StrataWiki fact/relation/snapshot table 기반 read projection
+  - `sql`
+    - StrataWiki fact/relation/snapshot table 기반 read projection
+  - `http`
+    - StrataWiki read endpoint 기반 projection
+    - `GET /api/v1/workspace-summary`
+    - `GET /api/v1/opportunities`
+    - `GET /api/v1/opportunities/:opportunityId`
+    - `GET /api/v1/calendar`
 - `workspace/ask`
   - read-backed baseline answer
   - profile context catalog 와 StrataWiki personal surface 가 모두 준비된 경우에만 personal-aware upgrade

--- a/apps/was/src/adapters/ask/stratawiki-personal-knowledge-client.js
+++ b/apps/was/src/adapters/ask/stratawiki-personal-knowledge-client.js
@@ -70,6 +70,117 @@ function ensureHttpMode(env, httpClient) {
   }
 }
 
+function mapSourceDocumentRef(sourceDocumentRef) {
+  if (!sourceDocumentRef || typeof sourceDocumentRef !== "object") {
+    return sourceDocumentRef
+  }
+
+  return {
+    document_id: sourceDocumentRef.document_id ?? sourceDocumentRef.documentId,
+    subspace: sourceDocumentRef.subspace,
+    version: sourceDocumentRef.version,
+    ...(sourceDocumentRef.kind ? { kind: sourceDocumentRef.kind } : {}),
+    ...(sourceDocumentRef.asset_refs
+      ? { asset_refs: sourceDocumentRef.asset_refs }
+      : sourceDocumentRef.assetRefs
+        ? { asset_refs: sourceDocumentRef.assetRefs }
+        : {}),
+  }
+}
+
+function mapSaveTarget(saveTarget) {
+  if (!saveTarget || typeof saveTarget !== "object") {
+    return saveTarget
+  }
+
+  return {
+    ...(saveTarget.document_id ? { document_id: saveTarget.document_id } : {}),
+    ...(saveTarget.documentId ? { document_id: saveTarget.documentId } : {}),
+    ...(saveTarget.subspace ? { subspace: saveTarget.subspace } : {}),
+    ...(saveTarget.version ? { version: saveTarget.version } : {}),
+  }
+}
+
+function normalizeInterpretationBuildPayload(payload = {}) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return payload
+  }
+
+  const normalized = { ...payload }
+  const partition =
+    payload.partition && typeof payload.partition === "object" && !Array.isArray(payload.partition)
+      ? payload.partition
+      : undefined
+  const subject =
+    payload.subject && typeof payload.subject === "object" && !Array.isArray(payload.subject)
+      ? payload.subject
+      : payload.subjectRef && typeof payload.subjectRef === "object" && !Array.isArray(payload.subjectRef)
+        ? payload.subjectRef
+        : undefined
+  const selection =
+    payload.selection && typeof payload.selection === "object" && !Array.isArray(payload.selection)
+      ? payload.selection
+      : undefined
+
+  const family =
+    selection?.family ??
+    partition?.family ??
+    (typeof payload.family === "string" ? payload.family : undefined)
+  const kind =
+    selection?.kind ??
+    partition?.kind ??
+    subject?.kind ??
+    (typeof payload.kind === "string" ? payload.kind : undefined)
+  const subjectId =
+    selection?.subject_id ??
+    subject?.id ??
+    subject?.subject_id ??
+    partition?.subject_id ??
+    partition?.segment
+  const subjectType =
+    selection?.subject_type ??
+    subject?.type ??
+    partition?.subject_type ??
+    (partition ? "market_segment" : undefined)
+  const subjectLabel =
+    selection?.subject_label ??
+    subject?.label ??
+    partition?.subject_label
+
+  if (!normalized.selection && typeof subjectId === "string" && subjectId.trim() !== "") {
+    normalized.selection = {
+      ...(family ? { family } : {}),
+      ...(kind ? { kind } : {}),
+      ...(subjectType ? { subject_type: subjectType } : {}),
+      subject_id: subjectId,
+      ...(subjectLabel ? { subject_label: subjectLabel } : {}),
+    }
+  }
+
+  if (!normalized.subject && normalized.selection) {
+    normalized.subject = {
+      ...(normalized.selection.subject_type ? { type: normalized.selection.subject_type } : {}),
+      id: normalized.selection.subject_id,
+      ...(normalized.selection.subject_label ? { label: normalized.selection.subject_label } : {}),
+    }
+  }
+
+  if (!normalized.partition && normalized.selection?.family) {
+    normalized.partition = {
+      family: normalized.selection.family,
+      segment: normalized.selection.subject_id,
+    }
+  }
+
+  delete normalized.subjectRef
+
+  return normalized
+}
+
+function normalizeExplanationLayer(layer) {
+  return layer === "personal_raw" || layer === "personal_wiki" ? "personal" : layer
+}
+
 export function createStratawikiPersonalKnowledgeClient({
   env = {},
   httpClient: providedHttpClient,
@@ -369,10 +480,10 @@ export function createStratawikiPersonalKnowledgeClient({
         domain,
         tenant_id: tenantId,
         user_id: userId,
-        source_document_ref: sourceDocumentRef,
+        source_document_ref: mapSourceDocumentRef(sourceDocumentRef),
         profile_version: profileVersion,
         model_profile: modelProfile,
-        save_target: saveTarget,
+        save_target: mapSaveTarget(saveTarget),
         ...(summaryStyle ? { summary_style: summaryStyle } : {}),
       }
 
@@ -401,10 +512,10 @@ export function createStratawikiPersonalKnowledgeClient({
         domain,
         tenant_id: tenantId,
         user_id: userId,
-        source_document_ref: sourceDocumentRef,
+        source_document_ref: mapSourceDocumentRef(sourceDocumentRef),
         profile_version: profileVersion,
         model_profile: modelProfile,
-        save_target: saveTarget,
+        save_target: mapSaveTarget(saveTarget),
         ...(rewriteGoal ? { rewrite_goal: rewriteGoal } : {}),
       }
 
@@ -433,10 +544,10 @@ export function createStratawikiPersonalKnowledgeClient({
         domain,
         tenant_id: tenantId,
         user_id: userId,
-        source_document_ref: sourceDocumentRef,
+        source_document_ref: mapSourceDocumentRef(sourceDocumentRef),
         profile_version: profileVersion,
         model_profile: modelProfile,
-        save_target: saveTarget,
+        save_target: mapSaveTarget(saveTarget),
         ...(structureTemplate ? { structure_template: structureTemplate } : {}),
       }
 
@@ -582,7 +693,7 @@ export function createStratawikiPersonalKnowledgeClient({
         () =>
           httpClient.getExplanation({
             domain,
-            layer,
+            layer: normalizeExplanationLayer(layer),
             recordId,
             tenantId,
             userId,
@@ -598,7 +709,7 @@ export function createStratawikiPersonalKnowledgeClient({
       return await runHttp(
         () =>
           httpClient.buildInterpretationSnapshot({
-            payload,
+            payload: normalizeInterpretationBuildPayload(payload),
           }),
         {
           toolName: "build_interpretation_snapshot",

--- a/apps/was/src/adapters/ask/stratawiki-personal-knowledge-client.js
+++ b/apps/was/src/adapters/ask/stratawiki-personal-knowledge-client.js
@@ -64,8 +64,11 @@ function ensureHttpMode(env, httpClient) {
   }
 
   if (!httpClient) {
-    throw new Error(
+    throw createTemporarilyUnavailableError(
       "Jobs-Wiki personal knowledge flows require STRATAWIKI_BASE_URL for HTTP mode.",
+      {
+        adapter: "stratawiki_personal_knowledge",
+      },
     )
   }
 }

--- a/apps/was/src/adapters/personal-document/stratawiki-personal-document-adapter.js
+++ b/apps/was/src/adapters/personal-document/stratawiki-personal-document-adapter.js
@@ -130,12 +130,22 @@ function buildGenerationTrace({ operation, sourceDocumentRef }) {
 
 export function createStratawikiPersonalDocumentAdapter({
   env = {},
-  personalKnowledgeClient = createStratawikiPersonalKnowledgeClient({ env }),
+  personalKnowledgeClient: providedPersonalKnowledgeClient = null,
 } = {}) {
   const profileContextCatalog = loadProfileContextCatalog(env.profileContextCatalogPath)
+  let personalKnowledgeClient = providedPersonalKnowledgeClient
+
+  function getPersonalKnowledgeClient() {
+    if (!personalKnowledgeClient) {
+      personalKnowledgeClient = createStratawikiPersonalKnowledgeClient({ env })
+    }
+
+    return personalKnowledgeClient
+  }
 
   return {
     async createPersonalDocument({ userContext, input }) {
+      const personalKnowledgeClient = getPersonalKnowledgeClient()
       const profileContextEntry = resolveWritableProfileContext({
         env,
         profileContextCatalog,
@@ -163,6 +173,7 @@ export function createStratawikiPersonalDocumentAdapter({
     },
 
     async updatePersonalDocument({ userContext, documentId, input }) {
+      const personalKnowledgeClient = getPersonalKnowledgeClient()
       const profileContextEntry = resolveWritableProfileContext({
         env,
         profileContextCatalog,
@@ -196,6 +207,7 @@ export function createStratawikiPersonalDocumentAdapter({
     },
 
     async deletePersonalDocument({ userContext, documentId, input }) {
+      const personalKnowledgeClient = getPersonalKnowledgeClient()
       const profileContextEntry = resolveWritableProfileContext({
         env,
         profileContextCatalog,
@@ -218,6 +230,7 @@ export function createStratawikiPersonalDocumentAdapter({
     },
 
     async registerPersonalAsset({ userContext, input }) {
+      const personalKnowledgeClient = getPersonalKnowledgeClient()
       const profileContextEntry = resolveWritableProfileContext({
         env,
         profileContextCatalog,
@@ -253,11 +266,6 @@ export function createStratawikiPersonalDocumentAdapter({
     },
 
     async generatePersonalWikiDocument({ userContext, documentId, input }) {
-      const profileContextEntry = resolveWritableProfileContext({
-        env,
-        profileContextCatalog,
-        userContext,
-      })
       const parsedDocumentId = parsePersonalLayerDocumentId(documentId)
 
       if (parsedDocumentId.layer !== "personal_raw") {
@@ -265,6 +273,13 @@ export function createStratawikiPersonalDocumentAdapter({
           "Raw-to-wiki generation requires a `personal_raw` source document.",
         )
       }
+
+      const personalKnowledgeClient = getPersonalKnowledgeClient()
+      const profileContextEntry = resolveWritableProfileContext({
+        env,
+        profileContextCatalog,
+        userContext,
+      })
 
       await ensureProfileContext({
         personalKnowledgeClient,
@@ -379,11 +394,6 @@ export function createStratawikiPersonalDocumentAdapter({
     },
 
     async suggestPersonalWikiLinks({ userContext, documentId, input }) {
-      const profileContextEntry = resolveWritableProfileContext({
-        env,
-        profileContextCatalog,
-        userContext,
-      })
       const parsedDocumentId = parsePersonalLayerDocumentId(documentId)
 
       if (parsedDocumentId.layer !== "personal_wiki") {
@@ -391,6 +401,13 @@ export function createStratawikiPersonalDocumentAdapter({
           "Wiki link suggestions require a `personal_wiki` document.",
         )
       }
+
+      const personalKnowledgeClient = getPersonalKnowledgeClient()
+      const profileContextEntry = resolveWritableProfileContext({
+        env,
+        profileContextCatalog,
+        userContext,
+      })
 
       await ensureProfileContext({
         personalKnowledgeClient,
@@ -415,11 +432,6 @@ export function createStratawikiPersonalDocumentAdapter({
     },
 
     async attachPersonalWikiLinks({ userContext, documentId, input }) {
-      const profileContextEntry = resolveWritableProfileContext({
-        env,
-        profileContextCatalog,
-        userContext,
-      })
       const parsedDocumentId = parsePersonalLayerDocumentId(documentId)
 
       if (parsedDocumentId.layer !== "personal_wiki") {
@@ -427,6 +439,13 @@ export function createStratawikiPersonalDocumentAdapter({
           "Wiki link attachment requires a `personal_wiki` document.",
         )
       }
+
+      const personalKnowledgeClient = getPersonalKnowledgeClient()
+      const profileContextEntry = resolveWritableProfileContext({
+        env,
+        profileContextCatalog,
+        userContext,
+      })
 
       return personalKnowledgeClient.attachPersonalWikiLinks({
         tenantId: profileContextEntry.tenantId,

--- a/apps/was/src/adapters/personal-document/stratawiki-personal-document-adapter.js
+++ b/apps/was/src/adapters/personal-document/stratawiki-personal-document-adapter.js
@@ -107,11 +107,11 @@ async function loadRuntimePersonalDocument({
 
 function buildSourceDocumentRef(document) {
   return {
-    document_id: document.document_id,
+    documentId: document.document_id,
     subspace: document.subspace,
     version: document.version,
-    kind: document.kind,
-    asset_refs: Array.isArray(document.asset_refs) ? document.asset_refs : [],
+    ...(document.kind ? { kind: document.kind } : {}),
+    assetRefs: Array.isArray(document.asset_refs) ? document.asset_refs : [],
   }
 }
 
@@ -119,7 +119,7 @@ function buildGenerationTrace({ operation, sourceDocumentRef }) {
   return [
     {
       step: "source",
-      message: `source_document_ref=${sourceDocumentRef.document_id}; subspace=${sourceDocumentRef.subspace}; version=${sourceDocumentRef.version}`,
+      message: `source_document_ref=${sourceDocumentRef.documentId}; subspace=${sourceDocumentRef.subspace}; version=${sourceDocumentRef.version}`,
     },
     {
       step: "operation",
@@ -305,7 +305,7 @@ export function createStratawikiPersonalDocumentAdapter({
             generatedAt: document?.updated_at ?? response?.updated_at ?? updatedAt,
             sourceDocument: {
               documentId,
-              title: sourceDocument.title ?? sourceDocumentRef.document_id,
+              title: sourceDocument.title ?? sourceDocumentRef.documentId,
               layer: parsedDocumentId.layer,
               version: sourceDocument.version ?? sourceDocumentRef.version,
             },
@@ -333,7 +333,7 @@ export function createStratawikiPersonalDocumentAdapter({
             generatedAt: document?.updated_at ?? response?.updated_at ?? updatedAt,
             sourceDocument: {
               documentId,
-              title: sourceDocument.title ?? sourceDocumentRef.document_id,
+              title: sourceDocument.title ?? sourceDocumentRef.documentId,
               layer: parsedDocumentId.layer,
               version: sourceDocument.version ?? sourceDocumentRef.version,
             },
@@ -361,7 +361,7 @@ export function createStratawikiPersonalDocumentAdapter({
             generatedAt: document?.updated_at ?? response?.updated_at ?? updatedAt,
             sourceDocument: {
               documentId,
-              title: sourceDocument.title ?? sourceDocumentRef.document_id,
+              title: sourceDocument.title ?? sourceDocumentRef.documentId,
               layer: parsedDocumentId.layer,
               version: sourceDocument.version ?? sourceDocumentRef.version,
             },

--- a/apps/was/src/adapters/read-authority/stratawiki-read-authority-adapter.js
+++ b/apps/was/src/adapters/read-authority/stratawiki-read-authority-adapter.js
@@ -1,5 +1,9 @@
 import { spawnSync } from "node:child_process"
 import {
+  StratawikiHttpError,
+  createStratawikiHttpClient,
+} from "../../../../../packages/integrations/stratawiki-http/client.js"
+import {
   createStratawikiPersonalKnowledgeClient,
 } from "../ask/stratawiki-personal-knowledge-client.js"
 import {
@@ -7,9 +11,11 @@ import {
   resolveProfileContextEntry,
 } from "../ask/profile-context-catalog.js"
 import {
+  createForbiddenError,
   createNotFoundError,
   createTemporarilyUnavailableError,
   createUnknownFailureError,
+  createValidationError,
 } from "../../http/errors.js"
 import { normalizeWorkspacePath } from "../../mappers/workspace-tree-model.js"
 
@@ -169,6 +175,49 @@ function compactObject(value) {
   return Object.fromEntries(
     Object.entries(value).filter(([, entryValue]) => entryValue !== undefined),
   )
+}
+
+function createHttpReadClient(env) {
+  if (!env.stratawikiBaseUrl) {
+    return null
+  }
+
+  return createStratawikiHttpClient({
+    baseUrl: env.stratawikiBaseUrl,
+    apiToken: env.stratawikiApiToken,
+    timeoutMs: env.stratawikiHttpTimeoutMs,
+  })
+}
+
+function toReadAuthorityError(error, { path }) {
+  if (!(error instanceof StratawikiHttpError)) {
+    return error
+  }
+
+  const details = {
+    adapter: "stratawiki_read_authority",
+    path,
+    requestId: error.requestId,
+    upstreamCode: error.code,
+  }
+
+  if (error.status === 404 || error.code === "not_found") {
+    return createNotFoundError(error.message, details)
+  }
+
+  if (error.status === 422 || error.code === "validation_error") {
+    return createValidationError(error.message, details)
+  }
+
+  if (error.status === 401 || error.status === 403 || error.code === "unauthorized") {
+    return createForbiddenError(error.message, details)
+  }
+
+  if (error.retryable) {
+    return createTemporarilyUnavailableError(error.message, details)
+  }
+
+  return createUnknownFailureError(error.message, details, error)
 }
 
 function getRoleLabel(roleRecord) {
@@ -1175,17 +1224,55 @@ export function createStratawikiReadAuthorityAdapter({
   env = {},
   queryJson = queryJsonWithPsql,
   now = () => new Date(),
+  httpClient: providedHttpClient,
   personalKnowledgeClient = createStratawikiPersonalKnowledgeClient({ env }),
 } = {}) {
   const profileContextCatalog = loadProfileContextCatalog(env.profileContextCatalogPath)
+  const readAuthorityMode = String(env.readAuthorityMode ?? "http").trim().toLowerCase()
+  const httpClient = providedHttpClient ?? createHttpReadClient(env)
+
+  async function runHttp(httpRun, { path }) {
+    try {
+      return await httpRun()
+    } catch (error) {
+      throw toReadAuthorityError(error, { path })
+    }
+  }
 
   return {
     async getWorkspace({ userContext } = {}) {
-      const readModel = await loadReadModel({
-        env,
-        queryJson,
-        now: now(),
-      })
+      const readModel =
+        readAuthorityMode === "http"
+          ? await runHttp(
+              async () => {
+                if (!httpClient) {
+                  throw new Error(
+                    "Jobs-Wiki HTTP read authority mode requires STRATAWIKI_BASE_URL.",
+                  )
+                }
+
+                const response = await httpClient.listOpportunities({
+                  domain: env.readDomain,
+                  scope: env.readScope,
+                  query: {
+                    limit: 3,
+                  },
+                })
+
+                return {
+                  opportunityItems: response?.items ?? [],
+                  sync: response?.sync ?? {
+                    visibility: "unknown",
+                  },
+                }
+              },
+              { path: "/api/v1/opportunities" },
+            )
+          : await loadReadModel({
+              env,
+              queryJson,
+              now: now(),
+            })
 
       return buildWorkspaceRecord(readModel, {
         env,
@@ -1196,6 +1283,25 @@ export function createStratawikiReadAuthorityAdapter({
     },
 
     async getWorkspaceSummary({ userContext } = {}) {
+      if (readAuthorityMode === "http") {
+        return await runHttp(
+          async () => {
+            if (!httpClient) {
+              throw new Error(
+                "Jobs-Wiki HTTP read authority mode requires STRATAWIKI_BASE_URL.",
+              )
+            }
+
+            return await httpClient.getWorkspaceSummary({
+              domain: env.readDomain,
+              scope: env.readScope,
+              profileId: userContext?.profileId,
+            })
+          },
+          { path: "/api/v1/workspace-summary" },
+        )
+      }
+
       const readModel = await loadReadModel({
         env,
         queryJson,
@@ -1223,6 +1329,25 @@ export function createStratawikiReadAuthorityAdapter({
     },
 
     async listOpportunities({ query } = {}) {
+      if (readAuthorityMode === "http") {
+        return await runHttp(
+          async () => {
+            if (!httpClient) {
+              throw new Error(
+                "Jobs-Wiki HTTP read authority mode requires STRATAWIKI_BASE_URL.",
+              )
+            }
+
+            return await httpClient.listOpportunities({
+              domain: env.readDomain,
+              scope: env.readScope,
+              query,
+            })
+          },
+          { path: "/api/v1/opportunities" },
+        )
+      }
+
       const readModel = await loadReadModel({
         env,
         queryJson,
@@ -1268,6 +1393,25 @@ export function createStratawikiReadAuthorityAdapter({
         })
       }
 
+      if (readAuthorityMode === "http") {
+        return await runHttp(
+          async () => {
+            if (!httpClient) {
+              throw new Error(
+                "Jobs-Wiki HTTP read authority mode requires STRATAWIKI_BASE_URL.",
+              )
+            }
+
+            return await httpClient.getOpportunity({
+              domain: env.readDomain,
+              scope: env.readScope,
+              opportunityId,
+            })
+          },
+          { path: `/api/v1/opportunities/${encodeURIComponent(opportunityId)}` },
+        )
+      }
+
       const readModel = await loadReadModel({
         env,
         queryJson,
@@ -1303,6 +1447,25 @@ export function createStratawikiReadAuthorityAdapter({
     },
 
     async getCalendar({ query } = {}) {
+      if (readAuthorityMode === "http") {
+        return await runHttp(
+          async () => {
+            if (!httpClient) {
+              throw new Error(
+                "Jobs-Wiki HTTP read authority mode requires STRATAWIKI_BASE_URL.",
+              )
+            }
+
+            return await httpClient.getCalendar({
+              domain: env.readDomain,
+              scope: env.readScope,
+              query,
+            })
+          },
+          { path: "/api/v1/calendar" },
+        )
+      }
+
       const readModel = await loadReadModel({
         env,
         queryJson,

--- a/apps/was/src/adapters/read-authority/stratawiki-read-authority-adapter.js
+++ b/apps/was/src/adapters/read-authority/stratawiki-read-authority-adapter.js
@@ -944,23 +944,15 @@ async function loadDocumentDetail({
       })
     }
 
-    const response =
-      /^personal:(raw|wiki):/.test(parsedDocumentId.recordId) ||
-      !parsedDocumentId.recordId.startsWith("personal:")
-        ? await personalKnowledgeClient.getPersonalDocument({
-            tenantId: profileContextEntry.tenantId,
-            userId: profileContextEntry.userId,
-            documentId: parsedDocumentId.recordId,
-          })
-        : await personalKnowledgeClient.getPersonalRecord({
-            tenantId: profileContextEntry.tenantId,
-            userId: profileContextEntry.userId,
-            personalId: parsedDocumentId.recordId,
-          })
+    const response = await personalKnowledgeClient.getPersonalDocument({
+      tenantId: profileContextEntry.tenantId,
+      userId: profileContextEntry.userId,
+      documentId: parsedDocumentId.recordId,
+    })
 
     return mapPersonalDocument(
       parsedDocumentId,
-      response?.document ?? response?.record ?? response,
+      response?.document ?? response,
     )
   }
 

--- a/apps/was/src/adapters/read-authority/stratawiki-read-authority-adapter.js
+++ b/apps/was/src/adapters/read-authority/stratawiki-read-authority-adapter.js
@@ -819,7 +819,7 @@ function mapPersonalWorkspaceItem(record, { subspace } = {}) {
 async function listPersonalWorkspaceItems({
   env,
   userContext,
-  personalKnowledgeClient,
+  getPersonalKnowledgeClient,
   profileContextCatalog,
 }) {
   const profileContextEntry = resolveProfileContextEntry({
@@ -828,7 +828,16 @@ async function listPersonalWorkspaceItems({
     domain: env.readDomain ?? "recruiting",
   })
 
-  if (!profileContextEntry || !personalKnowledgeClient.listPersonalDocuments) {
+  if (!profileContextEntry) {
+    return {
+      personalRawItems: [],
+      personalWikiItems: [],
+    }
+  }
+
+  const personalKnowledgeClient = getPersonalKnowledgeClient?.()
+
+  if (!personalKnowledgeClient?.listPersonalDocuments) {
     return {
       personalRawItems: [],
       personalWikiItems: [],
@@ -896,7 +905,7 @@ async function loadDocumentDetail({
   documentId,
   userContext,
   env,
-  personalKnowledgeClient,
+  getPersonalKnowledgeClient,
   profileContextCatalog,
 }) {
   const parsedDocumentId = parseWorkspaceDocumentId(documentId)
@@ -908,6 +917,8 @@ async function loadDocumentDetail({
   }
 
   if (parsedDocumentId.layer === "shared") {
+    const personalKnowledgeClient = getPersonalKnowledgeClient?.()
+
     if (parsedDocumentId.recordId.startsWith("interp:")) {
       const response = await personalKnowledgeClient.getInterpretationRecord({
         interpretationId: parsedDocumentId.recordId,
@@ -944,6 +955,8 @@ async function loadDocumentDetail({
       })
     }
 
+    const personalKnowledgeClient = getPersonalKnowledgeClient?.()
+
     const response = await personalKnowledgeClient.getPersonalDocument({
       tenantId: profileContextEntry.tenantId,
       userId: profileContextEntry.userId,
@@ -963,12 +976,12 @@ async function loadDocumentDetail({
 
 async function buildWorkspaceRecord(
   readModel,
-  { env, userContext, personalKnowledgeClient, profileContextCatalog } = {},
+  { env, userContext, getPersonalKnowledgeClient, profileContextCatalog } = {},
 ) {
   const personalItems = await listPersonalWorkspaceItems({
     env,
     userContext,
-    personalKnowledgeClient,
+    getPersonalKnowledgeClient,
     profileContextCatalog,
   })
 
@@ -1217,11 +1230,34 @@ export function createStratawikiReadAuthorityAdapter({
   queryJson = queryJsonWithPsql,
   now = () => new Date(),
   httpClient: providedHttpClient,
-  personalKnowledgeClient = createStratawikiPersonalKnowledgeClient({ env }),
+  personalKnowledgeClient: providedPersonalKnowledgeClient = null,
 } = {}) {
   const profileContextCatalog = loadProfileContextCatalog(env.profileContextCatalogPath)
   const readAuthorityMode = String(env.readAuthorityMode ?? "http").trim().toLowerCase()
   const httpClient = providedHttpClient ?? createHttpReadClient(env)
+  let personalKnowledgeClient = providedPersonalKnowledgeClient
+
+  function getPersonalKnowledgeClient() {
+    if (!personalKnowledgeClient) {
+      personalKnowledgeClient = createStratawikiPersonalKnowledgeClient({ env })
+    }
+
+    return personalKnowledgeClient
+  }
+
+  function requireHttpClient(path) {
+    if (!httpClient) {
+      throw createTemporarilyUnavailableError(
+        "Jobs-Wiki HTTP read authority mode requires STRATAWIKI_BASE_URL.",
+        {
+          adapter: "stratawiki_read_authority",
+          path,
+        },
+      )
+    }
+
+    return httpClient
+  }
 
   async function runHttp(httpRun, { path }) {
     try {
@@ -1237,13 +1273,9 @@ export function createStratawikiReadAuthorityAdapter({
         readAuthorityMode === "http"
           ? await runHttp(
               async () => {
-                if (!httpClient) {
-                  throw new Error(
-                    "Jobs-Wiki HTTP read authority mode requires STRATAWIKI_BASE_URL.",
-                  )
-                }
+                const client = requireHttpClient("/api/v1/opportunities")
 
-                const response = await httpClient.listOpportunities({
+                const response = await client.listOpportunities({
                   domain: env.readDomain,
                   scope: env.readScope,
                   query: {
@@ -1269,7 +1301,7 @@ export function createStratawikiReadAuthorityAdapter({
       return buildWorkspaceRecord(readModel, {
         env,
         userContext,
-        personalKnowledgeClient,
+        getPersonalKnowledgeClient,
         profileContextCatalog,
       })
     },
@@ -1278,13 +1310,9 @@ export function createStratawikiReadAuthorityAdapter({
       if (readAuthorityMode === "http") {
         return await runHttp(
           async () => {
-            if (!httpClient) {
-              throw new Error(
-                "Jobs-Wiki HTTP read authority mode requires STRATAWIKI_BASE_URL.",
-              )
-            }
+            const client = requireHttpClient("/api/v1/workspace-summary")
 
-            return await httpClient.getWorkspaceSummary({
+            return await client.getWorkspaceSummary({
               domain: env.readDomain,
               scope: env.readScope,
               profileId: userContext?.profileId,
@@ -1308,7 +1336,7 @@ export function createStratawikiReadAuthorityAdapter({
         documentId,
         userContext,
         env,
-        personalKnowledgeClient,
+        getPersonalKnowledgeClient,
         profileContextCatalog,
       })
 
@@ -1324,13 +1352,9 @@ export function createStratawikiReadAuthorityAdapter({
       if (readAuthorityMode === "http") {
         return await runHttp(
           async () => {
-            if (!httpClient) {
-              throw new Error(
-                "Jobs-Wiki HTTP read authority mode requires STRATAWIKI_BASE_URL.",
-              )
-            }
+            const client = requireHttpClient("/api/v1/opportunities")
 
-            return await httpClient.listOpportunities({
+            return await client.listOpportunities({
               domain: env.readDomain,
               scope: env.readScope,
               query,
@@ -1388,13 +1412,11 @@ export function createStratawikiReadAuthorityAdapter({
       if (readAuthorityMode === "http") {
         return await runHttp(
           async () => {
-            if (!httpClient) {
-              throw new Error(
-                "Jobs-Wiki HTTP read authority mode requires STRATAWIKI_BASE_URL.",
-              )
-            }
+            const client = requireHttpClient(
+              `/api/v1/opportunities/${encodeURIComponent(opportunityId)}`,
+            )
 
-            return await httpClient.getOpportunity({
+            return await client.getOpportunity({
               domain: env.readDomain,
               scope: env.readScope,
               opportunityId,
@@ -1442,13 +1464,9 @@ export function createStratawikiReadAuthorityAdapter({
       if (readAuthorityMode === "http") {
         return await runHttp(
           async () => {
-            if (!httpClient) {
-              throw new Error(
-                "Jobs-Wiki HTTP read authority mode requires STRATAWIKI_BASE_URL.",
-              )
-            }
+            const client = requireHttpClient("/api/v1/calendar")
 
-            return await httpClient.getCalendar({
+            return await client.getCalendar({
               domain: env.readDomain,
               scope: env.readScope,
               query,

--- a/apps/was/src/config/env.js
+++ b/apps/was/src/config/env.js
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url"
 
 const VALID_DATA_MODES = new Set(["mock", "real"])
 const VALID_INTEGRATION_MODES = new Set(["http"])
+const VALID_READ_AUTHORITY_MODES = new Set(["sql", "http"])
 
 const MODULE_DIR = dirname(fileURLToPath(import.meta.url))
 
@@ -88,6 +89,17 @@ export function loadEnv(overrides = {}) {
     )
   }
 
+  const readAuthorityMode =
+    rawEnv.JOBS_WIKI_READ_AUTHORITY_MODE ??
+    rawEnv.readAuthorityMode ??
+    "http"
+
+  if (!VALID_READ_AUTHORITY_MODES.has(readAuthorityMode)) {
+    throw new Error(
+      `Invalid JOBS_WIKI_READ_AUTHORITY_MODE: ${readAuthorityMode}. Expected one of ${Array.from(VALID_READ_AUTHORITY_MODES).join(", ")}`,
+    )
+  }
+
   return {
     serviceName: rawEnv.WAS_SERVICE_NAME ?? rawEnv.serviceName ?? "jobs-wiki-was",
     host: rawEnv.WAS_HOST ?? rawEnv.host ?? "127.0.0.1",
@@ -108,6 +120,7 @@ export function loadEnv(overrides = {}) {
     stratawikiApiToken:
       rawEnv.STRATAWIKI_API_TOKEN ?? rawEnv.stratawikiApiToken ?? null,
     stratawikiIntegrationMode,
+    readAuthorityMode,
     stratawikiHttpTimeoutMs: parseInteger(
       rawEnv.STRATAWIKI_HTTP_TIMEOUT_MS ?? rawEnv.stratawikiHttpTimeoutMs,
       10000,

--- a/apps/was/src/routes/document-routes.js
+++ b/apps/was/src/routes/document-routes.js
@@ -18,54 +18,104 @@ import {
   validateUpdateDocumentRequest,
 } from "../validators/document-validator.js"
 
+function compactObject(value) {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entryValue]) => entryValue !== undefined),
+  )
+}
+
+function readDocumentId(result) {
+  return result?.document_id ?? result?.documentId ?? result?.id ?? null
+}
+
+function readDocumentBodyMarkdown(result) {
+  return result?.body_markdown ?? result?.bodyMarkdown ?? ""
+}
+
+function readDocumentSummary(result) {
+  return result?.summary ?? result?.body_markdown ?? result?.bodyMarkdown ?? null
+}
+
+function readDocumentAssetRefs(result) {
+  if (Array.isArray(result?.asset_refs)) {
+    return result.asset_refs
+  }
+
+  if (Array.isArray(result?.assetRefs)) {
+    return result.assetRefs
+  }
+
+  return []
+}
+
+function mapGenerationSourceDocumentRef(result) {
+  const generationSourceDocument = result?.generation?.sourceDocument
+  const upstreamRef = result?.source_document_ref ?? result?.sourceDocumentRef
+
+  return compactObject({
+    documentId:
+      generationSourceDocument?.documentId ??
+      upstreamRef?.document_id ??
+      upstreamRef?.documentId,
+    title: generationSourceDocument?.title,
+    layer: generationSourceDocument?.layer,
+    version: generationSourceDocument?.version ?? upstreamRef?.version,
+    subspace: upstreamRef?.subspace,
+    kind: upstreamRef?.kind,
+    assetRefs: upstreamRef?.asset_refs ?? upstreamRef?.assetRefs,
+  })
+}
+
 function mapPersonalWikiGenerationResult(result) {
+  const documentId = readDocumentId(result)
+  const bodyMarkdown = readDocumentBodyMarkdown(result)
+
   return {
     item: mapDocumentDetail({
-      documentId: `personal_wiki:${result.document_id}`,
+      documentId: `personal_wiki:${documentId}`,
       title: result.title,
       layer: "personal_wiki",
       writable: true,
-      bodyMarkdown: result.body_markdown ?? "",
-      summary: result.body_markdown ?? null,
+      bodyMarkdown,
+      summary: readDocumentSummary(result),
       metadata: {
         source: {
           provider: "jobs_wiki_generation",
-          sourceId: result.document_id,
+          sourceId: documentId,
         },
-        updatedAt: result.updated_at ?? result.created_at,
+        updatedAt: result.updated_at ?? result.updatedAt ?? result.created_at ?? result.createdAt,
         version: result.version,
-        assetRefs: result.asset_refs ?? [],
+        assetRefs: readDocumentAssetRefs(result),
         status: result.status,
         generation: result.generation ?? undefined,
       },
       relatedObjects: [],
     }).item,
-    sourceDocumentRef: result.source_document_ref ?? null,
+    sourceDocumentRef: mapGenerationSourceDocumentRef(result),
   }
 }
 
 function mapDocumentPayloadFromMutation(input, result) {
   const workspacePath = result.workspace_path ?? result.workspacePath ?? input.workspacePath
+  const documentId = readDocumentId(result)
+  const bodyMarkdown = readDocumentBodyMarkdown(result)
 
   return mapDocumentDetail({
-    documentId: `${input.layer}:${result.document_id}`,
+    documentId: `${input.layer}:${documentId}`,
     title: result.title,
     layer: input.layer,
     writable: true,
-    bodyMarkdown: result.body_markdown ?? "",
-    summary: result.body_markdown ?? null,
+    bodyMarkdown,
+    summary: readDocumentSummary(result),
     workspacePath,
     metadata: {
       source: {
-        provider:
-          Array.isArray(result.asset_refs) && result.asset_refs.length > 0
-            ? "stratawiki_personal_asset"
-            : "stratawiki_personal",
-        sourceId: result.document_id,
+        provider: readDocumentAssetRefs(result).length > 0 ? "stratawiki_personal_asset" : "stratawiki_personal",
+        sourceId: documentId,
       },
-      updatedAt: result.updated_at ?? result.created_at,
+      updatedAt: result.updated_at ?? result.updatedAt ?? result.created_at ?? result.createdAt,
       version: result.version,
-      assetRefs: result.asset_refs ?? [],
+      assetRefs: readDocumentAssetRefs(result),
       status: result.status,
     },
     relatedObjects: [],

--- a/apps/was/test/app.test.js
+++ b/apps/was/test/app.test.js
@@ -538,6 +538,15 @@ test("personal raw-to-wiki generation and wiki link actions stay within the pers
     assert.match(wikiDocumentId, /^personal_wiki:/)
     assert.equal(summarizeResponse.body.item.metadata.generation.operation, "summarize")
     assert.equal(summarizeResponse.body.item.metadata.generation.provider, "mock")
+    assert.deepEqual(summarizeResponse.body.sourceDocumentRef, {
+      documentId: rawDocumentId,
+      title: "Research draft",
+      layer: "personal_raw",
+      version: 1,
+      subspace: "raw",
+      kind: "raw_document",
+      assetRefs: [],
+    })
     assert.ok(Array.isArray(summarizeResponse.body.item.metadata.generation.trace))
     assert.ok(
       !summarizeResponse.body.item.surface.bodyMarkdown.includes("generatedAt="),

--- a/apps/was/test/app.test.js
+++ b/apps/was/test/app.test.js
@@ -989,6 +989,7 @@ test("real command facade mode returns normalized temporary unavailability error
       port: 0,
       nodeEnv: "test",
       dataMode: "real",
+      STRATAWIKI_BASE_URL: "",
       logLevel: "silent",
     },
     async (app) => {
@@ -1242,6 +1243,7 @@ test("real adapter mode returns normalized temporary unavailability errors", asy
       port: 0,
       nodeEnv: "test",
       dataMode: "real",
+      STRATAWIKI_BASE_URL: "",
       logLevel: "silent",
     },
     async (app) => {
@@ -1264,6 +1266,7 @@ test("real document detail mode returns normalized temporary unavailability erro
       port: 0,
       nodeEnv: "test",
       dataMode: "real",
+      STRATAWIKI_BASE_URL: "",
       logLevel: "silent",
     },
     async (app) => {

--- a/apps/was/test/stratawiki-personal-knowledge-client.test.js
+++ b/apps/was/test/stratawiki-personal-knowledge-client.test.js
@@ -94,18 +94,23 @@ test("personal knowledge client uses HTTP-first resource endpoints when configur
   await client.getCacheStatus({
     tenantId: "tenant-1",
     userId: "user-1",
-    recordId: "personal:1",
+    recordId: "pdoc_raw_1",
   })
   await client.getExplanation({
-    layer: "personal",
-    recordId: "personal:1",
+    layer: "personal_wiki",
+    recordId: "pdoc_wiki_1",
     tenantId: "tenant-1",
     userId: "user-1",
   })
   const build = await client.buildInterpretationSnapshot({
     payload: {
       domain: "recruiting",
-      partition: { family: "market_trends", segment: "backend-mid" },
+      subject: {
+        type: "market_segment",
+        id: "backend-mid",
+        label: "Backend Mid",
+      },
+      family: "market_trends",
       fact_ids: ["fact:1"],
       fact_snapshot: "fact_snap:seed",
       model_profile: "balanced_default",
@@ -123,6 +128,13 @@ test("personal knowledge client uses HTTP-first resource endpoints when configur
   assert.equal(calls[1].kind, "profile")
   assert.equal(calls[2].kind, "personal_query")
   assert.equal(calls[3].payload.name, "get_personal_record")
+  assert.equal(calls.find((entry) => entry.kind === "explanation").payload.layer, "personal")
+  assert.deepEqual(calls.find((entry) => entry.kind === "build").payload.payload.selection, {
+    family: "market_trends",
+    subject_type: "market_segment",
+    subject_id: "backend-mid",
+    subject_label: "Backend Mid",
+  })
 })
 
 test("personal knowledge client rejects legacy non-http integration modes", () => {
@@ -192,7 +204,7 @@ test("personal knowledge client uses dedicated HTTP methods for personal CRUD, g
         calls.push({ kind: "create", payload })
         return {
           document: {
-            document_id: "personal:pdoc-1",
+            document_id: "pdoc_raw_1",
             title: payload.payload.title,
             version: 1,
           },
@@ -231,7 +243,7 @@ test("personal knowledge client uses dedicated HTTP methods for personal CRUD, g
         calls.push({ kind: "summarize", payload })
         return {
           document: {
-            document_id: "personal:wiki-1",
+            document_id: "pdoc_wiki_1",
             title: "Summary",
             version: 1,
             updated_at: "2026-04-21T00:00:00.000Z",
@@ -243,7 +255,7 @@ test("personal knowledge client uses dedicated HTTP methods for personal CRUD, g
         calls.push({ kind: "rewrite", payload })
         return {
           document: {
-            document_id: "personal:wiki-2",
+            document_id: "pdoc_wiki_2",
             title: "Rewrite",
             version: 1,
             updated_at: "2026-04-21T00:00:00.000Z",
@@ -254,7 +266,7 @@ test("personal knowledge client uses dedicated HTTP methods for personal CRUD, g
         calls.push({ kind: "structure", payload })
         return {
           document: {
-            document_id: "personal:wiki-3",
+            document_id: "pdoc_wiki_3",
             title: "Structure",
             version: 1,
             updated_at: "2026-04-21T00:00:00.000Z",
@@ -312,7 +324,7 @@ test("personal knowledge client uses dedicated HTTP methods for personal CRUD, g
   const document = await client.getPersonalDocument({
     tenantId: "tenant-1",
     userId: "user-1",
-    documentId: "personal:1",
+    documentId: "pdoc_raw_1",
   })
   const created = await client.createPersonalDocument({
     tenantId: "tenant-1",
@@ -325,7 +337,7 @@ test("personal knowledge client uses dedicated HTTP methods for personal CRUD, g
   const updated = await client.updatePersonalDocument({
     tenantId: "tenant-1",
     userId: "user-1",
-    documentId: "personal:1",
+    documentId: "pdoc_raw_1",
     profileVersion: "profile:v1",
     ifVersion: 1,
     title: "Draft v2",
@@ -333,7 +345,7 @@ test("personal knowledge client uses dedicated HTTP methods for personal CRUD, g
   const deleted = await client.deletePersonalDocument({
     tenantId: "tenant-1",
     userId: "user-1",
-    documentId: "personal:1",
+    documentId: "pdoc_raw_1",
     ifVersion: 2,
   })
   const asset = await client.registerPersonalAsset({
@@ -347,7 +359,7 @@ test("personal knowledge client uses dedicated HTTP methods for personal CRUD, g
   const summarized = await client.summarizePersonalDocumentToWiki({
     tenantId: "tenant-1",
     userId: "user-1",
-    sourceDocumentRef: { document_id: "personal:1", subspace: "raw", version: 1 },
+    sourceDocumentRef: { documentId: "pdoc_raw_1", subspace: "raw", version: 1 },
     profileVersion: "profile:v1",
     modelProfile: "balanced_default",
     saveTarget: { subspace: "wiki" },
@@ -355,7 +367,7 @@ test("personal knowledge client uses dedicated HTTP methods for personal CRUD, g
   const rewritten = await client.rewritePersonalDocumentToWiki({
     tenantId: "tenant-1",
     userId: "user-1",
-    sourceDocumentRef: { document_id: "personal:1", subspace: "raw", version: 1 },
+    sourceDocumentRef: { documentId: "pdoc_raw_1", subspace: "raw", version: 1 },
     profileVersion: "profile:v1",
     modelProfile: "balanced_default",
     saveTarget: { subspace: "wiki" },
@@ -363,7 +375,7 @@ test("personal knowledge client uses dedicated HTTP methods for personal CRUD, g
   const structured = await client.structurePersonalDocumentToWiki({
     tenantId: "tenant-1",
     userId: "user-1",
-    sourceDocumentRef: { document_id: "personal:1", subspace: "raw", version: 1 },
+    sourceDocumentRef: { documentId: "pdoc_raw_1", subspace: "raw", version: 1 },
     profileVersion: "profile:v1",
     modelProfile: "balanced_default",
     saveTarget: { subspace: "wiki" },
@@ -371,7 +383,7 @@ test("personal knowledge client uses dedicated HTTP methods for personal CRUD, g
   const suggestions = await client.suggestPersonalWikiLinks({
     tenantId: "tenant-1",
     userId: "user-1",
-    wikiDocumentId: "personal:wiki-1",
+    wikiDocumentId: "pdoc_wiki_1",
     wikiDocumentVersion: 1,
     profileVersion: "profile:v1",
     modelProfile: "balanced_default",
@@ -379,23 +391,28 @@ test("personal knowledge client uses dedicated HTTP methods for personal CRUD, g
   const attached = await client.attachPersonalWikiLinks({
     tenantId: "tenant-1",
     userId: "user-1",
-    wikiDocumentId: "personal:wiki-1",
+    wikiDocumentId: "pdoc_wiki_1",
     wikiDocumentVersion: 1,
     attachments: [{ layer: "fact", id: "fact:1" }],
   })
 
   assert.deepEqual(list, { documents: [] })
-  assert.equal(document.document.document_id, "personal:1")
-  assert.equal(created.document.document_id, "personal:pdoc-1")
+  assert.equal(document.document.document_id, "pdoc_raw_1")
+  assert.equal(created.document.document_id, "pdoc_raw_1")
   assert.equal(updated.document.version, 2)
   assert.equal(deleted.document.status, "deleted")
   assert.equal(asset.asset.asset_id, "passet_1")
-  assert.equal(summarized.document.document_id, "personal:wiki-1")
-  assert.equal(rewritten.document.document_id, "personal:wiki-2")
-  assert.equal(structured.document.document_id, "personal:wiki-3")
+  assert.equal(summarized.document.document_id, "pdoc_wiki_1")
+  assert.equal(rewritten.document.document_id, "pdoc_wiki_2")
+  assert.equal(structured.document.document_id, "pdoc_wiki_3")
   assert.equal(suggestions.suggestions.length, 1)
   assert.equal(attached.attached[0].id, "fact:1")
   assert.equal(calls.some((entry) => entry.kind === "tool"), false)
+  assert.deepEqual(calls[6].payload.payload.source_document_ref, {
+    document_id: "pdoc_raw_1",
+    subspace: "raw",
+    version: 1,
+  })
 })
 
 test("personal document adapter routes generation and link flows through the dedicated HTTP client methods", async () => {
@@ -516,6 +533,13 @@ test("personal document adapter routes generation and link flows through the ded
   assert.equal(generated.generation.operation, "summarize")
   assert.equal(generated.generation.provider, "stratawiki")
   assert.equal(generated.document_id, "pdoc_wiki_1")
+  assert.deepEqual(calls.find((entry) => entry.kind === "summarize").payload.sourceDocumentRef, {
+    documentId: "source-1",
+    subspace: "raw",
+    version: 1,
+    kind: "note",
+    assetRefs: [],
+  })
   assert.equal(suggestions.suggestions.length, 1)
   assert.equal(attached.attached.length, 1)
   assert.equal(

--- a/apps/was/test/stratawiki-read-authority-adapter.test.js
+++ b/apps/was/test/stratawiki-read-authority-adapter.test.js
@@ -603,7 +603,55 @@ test("real read adapter reclassifies legacy and drifted personal documents into 
 })
 
 test("real read adapter resolves wrapped shared and personal document ids", async () => {
-  const adapter = createAdapter()
+  const adapter = createAdapter({
+    personalKnowledgeClient: {
+      async getInterpretationRecord({ interpretationId }) {
+        return {
+          record: {
+            id: interpretationId,
+            title: "해석 문서",
+            summary: "shared interpretation summary",
+          },
+        }
+      },
+      async getFactRecord({ factId }) {
+        return {
+          record: {
+            id: factId,
+            attributes: {
+              title: "fact document",
+              summary: "fact summary",
+            },
+          },
+        }
+      },
+      async getPersonalRecord() {
+        throw new Error("workspace document detail should not fall back to getPersonalRecord")
+      },
+      async listPersonalDocuments({ subspace }) {
+        return {
+          items:
+            subspace === "wiki"
+              ? [{ document_id: "pdoc_002", subspace: "wiki", title: "wiki note" }]
+              : [{ document_id: "pdoc_001", subspace: "raw", title: "raw note" }],
+        }
+      },
+      async getPersonalDocument({ documentId }) {
+        return {
+          document: {
+            document_id: documentId,
+            subspace: "raw",
+            title: "runtime personal doc",
+            body_markdown: "## Runtime",
+            asset_refs: ["passet_1"],
+            version: 3,
+            status: "active",
+            updated_at: "2026-04-19T00:40:00.000Z",
+          },
+        }
+      },
+    },
+  })
   const shared = await adapter.getDocumentDetail({
     documentId: "shared:interp:published:1",
   })
@@ -620,7 +668,8 @@ test("real read adapter resolves wrapped shared and personal document ids", asyn
   assert.equal(shared.title, "해석 문서")
   assert.equal(personal.layer, "personal_raw")
   assert.equal(personal.writable, true)
-  assert.equal(personal.title, "personal note")
+  assert.equal(personal.title, "runtime personal doc")
+  assert.equal(personal.bodyMarkdown, "## Runtime")
 })
 
 test("real read adapter resolves runtime personal document ids from document CRUD flow", async () => {

--- a/apps/was/test/stratawiki-read-authority-adapter.test.js
+++ b/apps/was/test/stratawiki-read-authority-adapter.test.js
@@ -171,9 +171,11 @@ function createAdapter(overrides = {}) {
       readPsqlBin: "psql",
       readDomain: "recruiting",
       readScope: "shared",
+      readAuthorityMode: overrides.readAuthorityMode ?? "sql",
     },
     queryJson: createQueryJsonStub(overrides),
     now: () => new Date("2026-04-19T00:00:00.000Z"),
+    httpClient: overrides.httpClient,
     personalKnowledgeClient:
       overrides.personalKnowledgeClient ??
       {
@@ -293,6 +295,178 @@ test("real read adapter returns a fallback workspace summary when personal conte
   assert.equal(summary.recommendedOpportunities.length, 2)
   assert.equal(summary.marketBrief.notableCompanies[0], "인천교통공사")
   assert.equal(summary.skillsGap.recommendedToStrengthen.includes("Provision personal profile context"), true)
+})
+
+test("http read adapter proxies StrataWiki consumer-shaped read endpoints while preserving workspace assembly", async () => {
+  const httpClientCalls = []
+  const httpClient = {
+    async getWorkspaceSummary(params) {
+      httpClientCalls.push(["summary", params])
+      return {
+        profileSnapshot: {
+          targetRole: "Profile profile_demo_backend pending context hydration",
+        },
+        recommendedOpportunities: [
+          {
+            opportunityId: "opp_http_1",
+            title: "HTTP Imported Opportunity",
+          },
+        ],
+        marketBrief: {
+          notableCompanies: ["인천교통공사"],
+        },
+        skillsGap: {
+          recommendedToStrengthen: ["Provision personal profile context"],
+        },
+        sync: {
+          visibility: "applied",
+          version: "fact_snap:http",
+        },
+      }
+    },
+    async listOpportunities(params) {
+      httpClientCalls.push(["list", params])
+      return {
+        items: [
+          {
+            opportunityId: "opp_http_1",
+            objectId: "job_posting:http:1",
+            title: "HTTP Imported Opportunity",
+            summary: "Summary from HTTP",
+            companyName: "인천교통공사",
+            roleLabels: ["버스 운전원"],
+            status: "open",
+            source: {
+              provider: "worknet",
+              sourceId: "http-1",
+            },
+            company: {
+              name: "인천교통공사",
+            },
+            roles: [
+              {
+                objectId: "role:http:1",
+                label: "버스 운전원",
+              },
+            ],
+            qualification: {
+              locationText: "인천",
+            },
+            analysis: {
+              riskSummary: "source-only",
+            },
+            evidence: [
+              {
+                provenance: {
+                  connector: "worknet",
+                },
+              },
+            ],
+          },
+        ],
+        nextCursor: "cursor_001",
+        sync: {
+          visibility: "applied",
+          version: "fact_snap:http",
+        },
+      }
+    },
+    async getOpportunity(params) {
+      httpClientCalls.push(["detail", params])
+      return {
+        opportunityId: params.opportunityId,
+        title: "HTTP Imported Opportunity",
+        source: {
+          provider: "worknet",
+          sourceId: "http-1",
+        },
+        company: {
+          name: "인천교통공사",
+        },
+        roles: [
+          {
+            objectId: "role:http:1",
+            label: "버스 운전원",
+          },
+        ],
+        analysis: {
+          riskSummary: "source-only",
+        },
+        evidence: [
+          {
+            provenance: {
+              connector: "worknet",
+            },
+          },
+        ],
+        sync: {
+          visibility: "applied",
+          version: "fact_snap:http",
+        },
+      }
+    },
+    async getCalendar(params) {
+      httpClientCalls.push(["calendar", params])
+      return {
+        items: [
+          {
+            calendarItemId: "calendar_opp_http_1",
+            label: "HTTP Imported Opportunity closes",
+          },
+        ],
+        sync: {
+          visibility: "applied",
+          version: "fact_snap:http",
+        },
+      }
+    },
+  }
+
+  const adapter = createAdapter({
+    readAuthorityMode: "http",
+    httpClient,
+  })
+
+  const summary = await adapter.getWorkspaceSummary({
+    userContext: {
+      profileId: "profile_demo_backend",
+    },
+  })
+  const list = await adapter.listOpportunities({
+    query: {
+      limit: 1,
+    },
+  })
+  const detail = await adapter.getOpportunityDetail({
+    opportunityId: "opp_am9iX3Bvc3Rpbmc6MTU5NDM2",
+  })
+  const calendar = await adapter.getCalendar({
+    query: {
+      from: "2026-04-24",
+      to: "2026-04-30",
+    },
+  })
+  const workspace = await adapter.getWorkspace({
+    userContext: {
+      workspaceId: "workspace_demo",
+      profileId: "profile_demo_backend",
+    },
+  })
+
+  assert.equal(summary.sync.version, "fact_snap:http")
+  assert.equal(list.items[0].title, "HTTP Imported Opportunity")
+  assert.equal(detail.source.provider, "worknet")
+  assert.equal(calendar.items[0].calendarItemId, "calendar_opp_http_1")
+  assert.equal(workspace.sections[0].items[2].title, "HTTP Imported Opportunity")
+  assert.deepEqual(httpClientCalls.map(([name]) => name), [
+    "summary",
+    "list",
+    "detail",
+    "calendar",
+    "list",
+  ])
+  assert.equal(httpClientCalls[0][1].profileId, "profile_demo_backend")
+  assert.equal(httpClientCalls[4][1].query.limit, 3)
 })
 
 test("real read adapter builds workspace shell navigation from runtime personal documents", async () => {

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,9 @@
 
 현재 기준선은 `PKM workspace-first MVP` 입니다. 아래 문서들을 먼저 보고, 오래된 report-first 또는 generic PKM 방향 문서와 충돌하면 이 기준선을 우선합니다.
 
+이 문서의 역할은 **현재 제품 slice에서 어떤 문서를 우선 읽을지 정하는 precedence/guidance** 입니다.
+실제 제품 요구사항 내용은 `product/mvp-requirements-baseline.md`를 우선 기준으로 읽습니다.
+
 현재 레이어/디렉터리 해석:
 
 - `shared/`
@@ -59,6 +62,9 @@
 - `api/workspace-mvp-read-contract.md`
 - `architecture/stratawiki-web-integration.md`
 - `architecture/web-service-requirements-analysis.md`
+
+단, `architecture/stratawiki-web-integration.md`는 **현재 제품 slice의 1차 기준 문서**는 아니지만,
+`Jobs-Wiki -> StrataWiki` 통합 경계를 판단할 때는 여전히 **integration concern의 primary doc** 로 취급합니다.
 
 ## Current MVP Run And Verify
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,14 @@
 
 ## Goal
 
-이 시스템은 채용, 직업, 기업, 학과, 훈련 정보를 사용자별 지식 공간으로 재구성해 제공하는 웹 서비스를 목표로 합니다.
+이 시스템은 채용, 직업, 기업, 학과, 훈련 정보를 사용자별 markdown-native workspace로 재구성해 제공하는 웹 서비스를 목표로 합니다.
+
+핵심 방향은 아래와 같습니다.
+
+- 제품의 중심은 personal wiki/workspace 입니다.
+- shared layer는 무거운 완결형 knowledge graph가 아니라 lightweight shared substrate 입니다.
+- `Jobs-Wiki`는 recruiting domain semantics 와 workspace UX 를 소유합니다.
+- `StrataWiki`는 shared `Fact`/`Interpretation` runtime 과 governance 를 소유합니다.
 
 ## Components
 
@@ -31,6 +38,8 @@ canonical write 반영 -> external backend ownership 범위
 - Jobs-Wiki의 핵심 읽기 모델은 file list만이 아니라 workspace projection입니다.
 - tree, document, graph, calendar, search, workspace summary는 같은 knowledge space의 서로 다른 projection으로 취급합니다.
 - projection은 canonical object/relation에서 파생된 user-visible read shape이며, command 결과보다 늦게 반영될 수 있습니다.
+- workspace의 실제 작업 표면은 personal markdown 문서입니다.
+- shared `Fact`/`Interpretation`은 workspace를 보조하는 retrieval substrate로 사용됩니다.
 
 현재 draft 기준선:
 
@@ -48,8 +57,29 @@ canonical write 반영 -> external backend ownership 범위
 - integrations는 외부 서비스 규칙을 캡슐화하며 WAS와 Ingestion이 함께 사용할 수 있습니다.
 - read authority는 user-visible knowledge state의 external read-serving authority입니다.
 - MCP facade는 user intent를 external command로 위임하는 경계입니다.
+- `Jobs-Wiki`는 domain routing, domain pack authoring, source normalization, personal workspace UX 를 소유합니다.
+- `StrataWiki` 같은 external backend 는 canonical shared storage, shared interpretation lifecycle, snapshot, governance 를 소유합니다.
 - canonical storage가 별도 backend에 있다면 그 ownership은 해당 backend에 있습니다.
 - 외부 소비자는 이 레포의 내부 코드를 직접 의존하지 않습니다.
+
+## StrataWiki Boundary
+
+현재 기준에서 `Jobs-Wiki` 와 `StrataWiki` 의 분리는 아래처럼 이해하는 것이 맞습니다.
+
+- `Jobs-Wiki`
+  - recruiting domain 의미 정의
+  - source ingest 와 normalization
+  - domain pack 제안
+  - proposal 생성
+  - personal workspace 와 editor UX
+- `StrataWiki`
+  - canonical `Fact` 저장
+  - shared `Interpretation` 저장
+  - pack validation / activation / enforcement
+  - snapshot / stale / provenance / retrieval substrate
+
+즉 `Jobs-Wiki` 가 의미를 정의하고 제품 경험을 소유하며,
+`StrataWiki` 는 shared runtime 을 안전하게 운영합니다.
 
 ## Sync and Visibility Direction
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -8,7 +8,7 @@
 
 - 제품의 중심은 personal wiki/workspace 입니다.
 - shared layer는 무거운 완결형 knowledge graph가 아니라 lightweight shared substrate 입니다.
-- `Jobs-Wiki`는 recruiting domain semantics 와 workspace UX 를 소유합니다.
+- `Jobs-Wiki`는 recruiting domain semantics, interpretation grammar, workspace UX 를 소유합니다.
 - `StrataWiki`는 shared `Fact`/`Interpretation` runtime 과 governance 를 소유합니다.
 
 ## Components
@@ -57,7 +57,7 @@ canonical write 반영 -> external backend ownership 범위
 - integrations는 외부 서비스 규칙을 캡슐화하며 WAS와 Ingestion이 함께 사용할 수 있습니다.
 - read authority는 user-visible knowledge state의 external read-serving authority입니다.
 - MCP facade는 user intent를 external command로 위임하는 경계입니다.
-- `Jobs-Wiki`는 domain routing, domain pack authoring, source normalization, personal workspace UX 를 소유합니다.
+- `Jobs-Wiki`는 domain routing, domain pack authoring, source normalization, recruiting interpretation grammar, personal workspace UX 를 소유합니다.
 - `StrataWiki` 같은 external backend 는 canonical shared storage, shared interpretation lifecycle, snapshot, governance 를 소유합니다.
 - canonical storage가 별도 backend에 있다면 그 ownership은 해당 backend에 있습니다.
 - 외부 소비자는 이 레포의 내부 코드를 직접 의존하지 않습니다.
@@ -68,6 +68,7 @@ canonical write 반영 -> external backend ownership 범위
 
 - `Jobs-Wiki`
   - recruiting domain 의미 정의
+  - recruiting interpretation family/kind grammar 정의
   - source ingest 와 normalization
   - domain pack 제안
   - proposal 생성

--- a/docs/architecture/repo-work-breakdown.md
+++ b/docs/architecture/repo-work-breakdown.md
@@ -29,6 +29,7 @@ status: draft
 - opportunity/report/calendar presentation
 - user-visible command flow
 - adapter wiring and fallback policy
+- consumer of StrataWiki read-serving contract, not the contract owner
 
 ### StrataWiki owns
 
@@ -39,6 +40,16 @@ status: draft
 - interpretation lifecycle
 - personal artifact storage contract if stored in personal layer
 - LLM runtime policy and retrieval discipline
+- authoritative read-serving data contract for external consumers
+
+## Graph Naming
+
+- `StrataWiki internal graph`
+  - dependency / invalidation / retrieval support graph
+  - operator/runtime concern
+- `Jobs-Wiki workspace graph projection`
+  - user-facing node/edge visualization
+  - product projection concern
 
 ## Work Breakdown By Epic
 
@@ -57,6 +68,7 @@ status: draft
 - shell이 읽을 수 있는 최소 navigation/read contract 제공 여부 결정
 - shared/personal object ref shape 제공
 - current active context와 layer visibility를 표현할 수 있는 personal/read contract 정리
+- consumer-shaped HTTP read endpoint 제공
 
 ## 2. Document Detail
 
@@ -189,6 +201,7 @@ status: draft
 ## Anti-patterns
 
 - Jobs-Wiki가 StrataWiki DB를 직접 write
+- Jobs-Wiki가 StrataWiki canonical read DB를 장기 기본 경계로 유지
 - Jobs-Wiki가 personal layer schema를 ad-hoc로 복제
 - StrataWiki가 frontend route/view model naming까지 직접 소유
 - personal wiki generation 결과를 shared update처럼 표시

--- a/docs/architecture/stratawiki-domain-bridge.md
+++ b/docs/architecture/stratawiki-domain-bridge.md
@@ -11,7 +11,7 @@ status: draft
 특히 아래 질문에 답하는 것이 목적입니다.
 
 - `WorkNet`, `RSS`, `Gmail` 같은 서로 다른 source를 어떤 공통 경계로 다룰 것인가
-- `StrataWiki`의 `DomainIngestionPlugin` 구조와 어떻게 맞물리게 할 것인가
+- `StrataWiki`의 domain pack / proposal ingestion 구조와 어떻게 맞물리게 할 것인가
 - `Jobs-Wiki`가 어떤 정보를 어디까지 정규화해서 넘기는 편이 맞는가
 - source 추가와 domain 추가를 어떻게 분리해서 설계할 것인가
 
@@ -67,18 +67,18 @@ status: draft
 
 현재 `StrataWiki`의 ingestion 핵심 계약은 의외로 작습니다.
 
-- common `SourceRecord`
-- domain-specific `DomainIngestionPlugin`
-- plugin이 `FactRecord`와 `FactRelation`을 생성
+- versioned domain pack
+- domain proposal batch
+- proposal ingestion gate가 canonical Fact/Relation을 생성
 
-즉 `StrataWiki`는 source fetcher에 의존하지 않고, "공통 source envelope를 어떤 domain plugin이 해석하느냐"에 의존합니다.
+즉 `StrataWiki`는 source fetcher에 의존하지 않고, "어떤 domain pack 규칙으로 proposal을 canonicalize 하느냐"에 의존합니다.
 
 따라서 `Jobs-Wiki`가 해야 할 일도 다음처럼 좁게 가져가는 편이 맞습니다.
 
 - source-specific API 규칙 흡수
 - source-oriented normalized payload 생성
-- target domain이 해석할 수 있는 bridge envelope 생성
-- 그 이후 canonical fact decomposition은 `StrataWiki` domain plugin에 맡김
+- target domain에 맞는 proposal batch 생성
+- 그 이후 canonical fact decomposition과 lifecycle은 `StrataWiki`에 맡김
 
 ## Recommended Compatibility Pipeline
 
@@ -88,9 +88,9 @@ status: draft
 Third-party source
   -> Jobs-Wiki integration package
   -> source-oriented normalized payload
-  -> Jobs-Wiki domain router / bridge adapter
-  -> StrataWiki-compatible source envelope
-  -> StrataWiki DomainIngestionPlugin
+  -> Jobs-Wiki domain router / proposal mapper
+  -> StrataWiki-compatible DomainProposalBatch
+  -> StrataWiki proposal ingestion gate
   -> Fact / Relation / Snapshot
 ```
 
@@ -111,19 +111,20 @@ Third-party source
 - `RssFeedEntryPayload`
 - `GmailMessagePayload`
 
-### Domain Router / Bridge Adapter
+### Domain Router / Proposal Mapper
 
 책임:
 
 - 어떤 domain으로 보낼지 결정
-- payload를 `StrataWiki`가 읽을 수 있는 common source envelope로 변환
+- payload를 `StrataWiki`가 읽을 수 있는 proposal batch로 변환
 - payload version, provider, source kind 같은 bridge metadata 부착
+- domain pack 의미에 맞는 identity hint, evidence, relation proposal 생성
 
-### StrataWiki Domain Plugin
+### StrataWiki Proposal Ingestion Gate
 
 책임:
 
-- normalized source envelope를 domain 의미로 해석
+- registered domain pack을 기준으로 proposal을 검증
 - fact entity와 relation 생성
 - validation 수행
 - freshness/dedupe/lifecycle 정책 적용
@@ -143,18 +144,41 @@ Third-party source
 
 - source normalized payload types
 - domain routing policy
-- `StrataWiki` bridge request/response contract
+- `StrataWiki` proposal request/response contract
+- domain pack semantics for recruiting
 
 반면 `StrataWiki`가 소유해야 하는 것은 아래입니다.
 
-- domain plugin semantics
+- pack registry and governance
 - fact decomposition rules
-- interpretation/personal generation semantics
+- interpretation runtime semantics
 - storage/snapshot ownership
 
 ## Candidate Bridge Contract
 
-현재 `StrataWiki`의 `SourceRecord` 철학에 맞춰, `Jobs-Wiki`에서는 아래 같은 JSON-level contract를 기준으로 잡는 편이 유력합니다.
+현재 기준에서 preferred contract 는 source envelope 보다 `DomainProposalBatch` 입니다.
+
+예:
+
+```ts
+type DomainProposalBatch = {
+  batch_id?: string;
+  domain: string;
+  producer: string;
+  pack_version?: string;
+  facts: FactProposal[];
+  relations: RelationProposal[];
+};
+```
+
+이 contract 의 의미는 아래와 같습니다.
+
+- `Jobs-Wiki` 는 source oriented payload 를 domain semantics 에 맞는 proposal 로 바꿉니다.
+- `StrataWiki` 는 proposal 의 canonical acceptance 와 storage 를 담당합니다.
+
+Legacy envelope style 을 설명해야 할 경우에는 아래처럼 이해합니다.
+
+현재 `StrataWiki`의 과거 `SourceRecord` 철학에 맞춰, `Jobs-Wiki`에서는 아래 같은 JSON-level contract도 설명할 수 있습니다.
 
 ```ts
 type StrataWikiSourceEnvelope = {

--- a/docs/architecture/stratawiki-domain-bridge.md
+++ b/docs/architecture/stratawiki-domain-bridge.md
@@ -78,6 +78,7 @@ status: draft
 - source-specific API 규칙 흡수
 - source-oriented normalized payload 생성
 - target domain에 맞는 proposal batch 생성
+- 필요 시 training/news 같은 supporting source를 recruiting interpretation evidence로 라우팅
 - 그 이후 canonical fact decomposition과 lifecycle은 `StrataWiki`에 맡김
 
 ## Recommended Compatibility Pipeline
@@ -119,6 +120,11 @@ Third-party source
 - payload를 `StrataWiki`가 읽을 수 있는 proposal batch로 변환
 - payload version, provider, source kind 같은 bridge metadata 부착
 - domain pack 의미에 맞는 identity hint, evidence, relation proposal 생성
+
+recruiting v2 기준 추가 원칙:
+
+- training/news source는 우선 recruiting fact 확대가 아니라 recruiting interpretation evidence 확장으로 취급합니다.
+- 즉 같은 source라도 `primary_fact_source`인지 `supporting_interpretation_source`인지 구분해 라우팅하는 편이 맞습니다.
 
 ### StrataWiki Proposal Ingestion Gate
 

--- a/docs/architecture/stratawiki-domain-pack.md
+++ b/docs/architecture/stratawiki-domain-pack.md
@@ -64,6 +64,7 @@ Domain Pack
   = identity / merge rules
   = proposal validation rules
   = projection hints
+  = interpretation grammar guidance
 
 Jobs-Wiki
   = recruiting domain pack owner
@@ -184,7 +185,7 @@ type ProjectionHints = {
 {
   "manifest": {
     "domain": "recruiting",
-    "packVersion": "2026-04-18",
+    "packVersion": "2026-04-22",
     "compatibility": {
       "minStrataWikiVersion": "0.2.0"
     },

--- a/docs/architecture/stratawiki-schema-governance.md
+++ b/docs/architecture/stratawiki-schema-governance.md
@@ -43,6 +43,7 @@ status: draft
 - proposal quality tests
 - pack evolution proposal
 - interpretation family/kind grammar for the recruiting domain
+- training/news source expansion criteria for recruiting interpretations
 - personal workspace UX and markdown-native product behavior
 
 ## Architectural Position

--- a/docs/architecture/stratawiki-schema-governance.md
+++ b/docs/architecture/stratawiki-schema-governance.md
@@ -15,6 +15,7 @@ status: draft
 - `Jobs-Wiki`는 domain semantics를 제안하고 소유합니다.
 - `StrataWiki`는 schema governance와 runtime enforcement를 소유합니다.
 - 즉 `Jobs-Wiki`가 제안하고, `StrataWiki`가 승인하고 집행합니다.
+- `Jobs-Wiki`는 product/workspace owner이기도 하며, shared substrate를 최종 사용자 경험으로 재구성합니다.
 
 ## Ownership Split
 
@@ -29,6 +30,8 @@ status: draft
 - merge / conflict policy execution
 - runtime ingestion gate
 - pack lifecycle state
+- shared `Fact`/`Interpretation` storage
+- snapshot / provenance / stale lifecycle
 
 ### Jobs-Wiki
 
@@ -39,6 +42,17 @@ status: draft
 - domain fixtures
 - proposal quality tests
 - pack evolution proposal
+- interpretation family/kind grammar for the recruiting domain
+- personal workspace UX and markdown-native product behavior
+
+## Architectural Position
+
+이 ownership split 은 단순 ingestion 분리가 아니라 제품 구조와도 연결됩니다.
+
+- `StrataWiki` 는 lightweight shared substrate runtime 입니다.
+- `Jobs-Wiki` 는 recruiting domain product 입니다.
+- 따라서 `Jobs-Wiki` 는 shared layer 를 그대로 노출하는 것이 아니라 personal workspace 경험으로 재구성합니다.
+- personal layer 의 본체는 markdown 문서이며, shared layer 는 그 personal workspace 를 돕는 공용 context 공급층입니다.
 
 ## StrataWiki Agent Backlog
 

--- a/docs/architecture/stratawiki-web-integration.md
+++ b/docs/architecture/stratawiki-web-integration.md
@@ -14,7 +14,15 @@ status: draft
 - direct DB access 금지와 read DB 사용의 차이
 - read DB boundary 와 HTTP boundary 의 차이
 
-이 문서는 **현재 구현 baseline** 을 기준으로 읽어야 합니다.
+이 문서는 **current baseline** 과 **target baseline** 을 분리해서 읽어야 합니다.
+
+- current baseline
+  - write / personal / command 는 HTTP 입니다.
+  - read 는 `JOBS_WIKI_READ_AUTHORITY_MODE=sql|http` 로 병행 가능합니다.
+  - default read authority 는 이제 `http` 입니다.
+- target baseline
+  - read / write / personal / command 모두 HTTP 입니다.
+  - Jobs-Wiki 는 StrataWiki canonical DB 에 직접 연결하지 않습니다.
 
 ## Current Runtime Split
 
@@ -38,22 +46,26 @@ StrataWiki canonical write surface 로 전달합니다.
 
 ### 2. WAS read path
 
-`apps/was` 의 `WAS_DATA_MODE=real` 은 StrataWiki canonical read DB 를 직접 읽어
-user-facing projection 을 만듭니다.
+`apps/was` 의 `WAS_DATA_MODE=real` 은 read authority mode 에 따라
+두 경로 중 하나로 user-facing projection 을 만듭니다.
 
 이 read path 원칙:
 
-- `STRATAWIKI_READ_DATABASE_URL` 로 read DB 에 연결합니다.
-- `STRATAWIKI_READ_PSQL_BIN` 으로 SQL read process 를 실행합니다.
-- read 대상은 canonical snapshot / fact / relation state 입니다.
-- 이 direct DB usage 는 **read-only projection assembly** 용도입니다.
-- 이것은 write path 가 아니며, personal knowledge write path 도 아닙니다.
+- `JOBS_WIKI_READ_AUTHORITY_MODE=sql`
+  - deprecated fallback path 입니다.
+  - `STRATAWIKI_READ_DATABASE_URL` 로 read DB 에 연결합니다.
+  - `STRATAWIKI_READ_PSQL_BIN` 으로 SQL read process 를 실행합니다.
+  - read 대상은 canonical snapshot / fact / relation state 입니다.
+- `JOBS_WIKI_READ_AUTHORITY_MODE=http`
+  - current default 입니다.
+  - StrataWiki read model endpoint 를 호출합니다.
+  - canonical table shape 가 아니라 consumer-shaped projection contract 를 사용합니다.
 
-따라서 "Jobs-Wiki 는 DB 에 직접 접근하지 않는다" 는 표현은 현재 구현과 다릅니다.
-정확한 표현은 아래입니다.
+따라서 현재 구현을 정확히 적으면 아래와 같습니다.
 
 - direct DB write 는 하지 않는다
-- real WAS projection 을 위해 canonical read DB 는 직접 읽는다
+- read 의 default 는 HTTP 이고 SQL path 는 fallback 으로 남아 있다
+- migration target 은 direct DB read 제거다
 
 ### 3. WAS ask path
 
@@ -163,7 +175,17 @@ WorkNet source
 - `GET /api/calendar`
 - `GET /api/workspace/sync`
 
-이 route 들은 StrataWiki read DB 로부터 projection 을 조합합니다.
+이 route 들은 read authority mode 에 따라 다르게 동작합니다.
+
+- `sql`
+  - StrataWiki read DB 로부터 projection 을 조합합니다.
+- `http`
+  - StrataWiki read endpoint 를 직접 호출합니다.
+  - 현재 endpoint baseline:
+    - `GET /api/v1/workspace-summary`
+    - `GET /api/v1/opportunities`
+    - `GET /api/v1/opportunities/{opportunity_id}`
+    - `GET /api/v1/calendar`
 
 ### WAS ask
 
@@ -212,9 +234,13 @@ POST /api/workspace/ask
   - current baseline 은 `http`
   - legacy `auto|wrapper` compatibility path 는 운영 기준선으로 설명하지 않습니다
 - `STRATAWIKI_BASE_URL`
-  - ask / personal document / command integration base URL
+  - ask / personal document / command / HTTP read integration base URL
 - `STRATAWIKI_API_TOKEN`
   - auth-enabled HTTP 환경용 bearer token
+- `JOBS_WIKI_READ_AUTHORITY_MODE`
+  - `sql|http`
+  - current default 는 `http`
+  - `sql` 은 제거 대상 fallback
 - `STRATAWIKI_HTTP_TIMEOUT_MS`
   - HTTP timeout
 - `STRATAWIKI_CLI_WRAPPER`
@@ -224,9 +250,11 @@ POST /api/workspace/ask
 - `JOBS_WIKI_STRATAWIKI_ACTIVE_DOMAIN_PACKS`
   - optional active pack mapping
 - `STRATAWIKI_READ_DATABASE_URL`
-  - WAS real read adapter 전용 read DB connection string
+  - `sql` read authority mode 에서만 사용
+  - deprecated target
 - `STRATAWIKI_READ_PSQL_BIN`
-  - WAS read-side SQL query process
+  - `sql` read authority mode 에서만 사용
+  - deprecated target
 - `JOBS_WIKI_PROFILE_CONTEXT_CATALOG_PATH`
   - ask personal-aware upgrade 시도에 사용할 profile catalog
 
@@ -247,6 +275,11 @@ StrataWiki runtime 자체가 책임지는 env 와 Jobs-Wiki 가 소유하는 env
 
 현재 코드가 **실제로 main path 에서 사용하는** StrataWiki surface:
 
+- HTTP read endpoint family
+  - `GET /api/v1/workspace-summary`
+  - `GET /api/v1/opportunities`
+  - `GET /api/v1/opportunities/{opportunity_id}`
+  - `GET /api/v1/calendar`
 - `POST /api/v1/domain-proposals/validate`
 - `POST /api/v1/domain-proposals/ingest`
 - `PUT /api/v1/profile-contexts/{tenant_id}/{user_id}`
@@ -323,12 +356,19 @@ npm run smoke:http
 - frontend 가 personal knowledge object graph 를 직접 이해하는 계약
 - read-backed ask 를 personal-aware ask 로 전면 대체했다는 설명
 
+graph terminology note:
+
+- StrataWiki graph
+  - internal dependency / retrieval support concern
+- Jobs-Wiki graph
+  - user-facing projection concern
+
 ## Rule Of Thumb
 
 현재 구현을 한 줄로 요약하면 아래가 가장 정확합니다.
 
 - write 는 HTTP 우선, wrapper 는 rollback
-- read 는 canonical read DB
+- read 는 `http` default + `sql` fallback
 - ask 는 read-backed baseline 위에 optional personal-aware upgrade
 - sync/admin 은 HTTP command facade
 - target PKM structure 는 future direction 이지 shipped surface 가 아니다

--- a/docs/architecture/stratawiki-web-integration.md
+++ b/docs/architecture/stratawiki-web-integration.md
@@ -16,6 +16,9 @@ status: draft
 
 이 문서는 **current baseline** 과 **target baseline** 을 분리해서 읽어야 합니다.
 
+또한 이 문서는 `docs/README.md`에서 current product slice 기준으로는 secondary/background 문서로 분류되지만,
+`Jobs-Wiki -> StrataWiki` 통합 경계를 판단할 때는 여전히 **integration concern의 primary doc** 으로 취급합니다.
+
 - current baseline
   - write / personal / command 는 HTTP 입니다.
   - read 는 `JOBS_WIKI_READ_AUTHORITY_MODE=sql|http` 로 병행 가능합니다.

--- a/docs/domain/recruiting-domain-pack.md
+++ b/docs/domain/recruiting-domain-pack.md
@@ -8,27 +8,48 @@ status: draft
 
 Draft.
 
-이 문서는 `Jobs-Wiki`가 소유하는 `recruiting` domain pack v1 초안을 정리합니다.
-현재 목표는 `StrataWiki` validator contract를 최종 확정하는 것이 아니라,
-WorkNet 기반 첫 mapper 작업이 바로 붙을 수 있을 정도의 최소 semantic baseline을 고정하는 것입니다.
+이 문서는 `Jobs-Wiki`가 소유하는 `recruiting` domain pack v2 초안을 정리합니다.
+v2의 핵심은 fact surface를 크게 넓히는 것이 아니라,
+v1의 최소 recruiting fact baseline 위에 interpretation grammar, source expansion policy,
+evidence/quality guidance를 domain-owned artifact로 명시하는 것입니다.
 
 ## Purpose
 
 - `Jobs-Wiki`가 소유할 recruiting canonical vocabulary를 최소 범위로 정합니다.
 - 어떤 candidate를 Fact/Relation으로 승격하고, 어떤 candidate를 attribute로 남길지 결정합니다.
 - WorkNet `open_recruitment` payload가 어떤 identity hint를 생성해야 하는지 정합니다.
+- recruiting interpretation family/kind grammar와 source expansion 기준을 정합니다.
 - product UI shape를 canonical schema로 고정하지 않습니다.
 
 ## Pack Artifact
 
-- Artifact: `packages/domain-packs/recruiting/v1.json`
-- Current source profile: `worknet.open_recruitment`
+- Primary artifact: `packages/domain-packs/recruiting/v2.json`
+- Historical baseline: `packages/domain-packs/recruiting/v1.json`
+- Current fact source profile: `worknet.open_recruitment`
+- Adjacent grammar doc: `docs/domain/recruiting-interpretation-grammar.md`
 
 이 artifact는 runtime code가 아니라, `Jobs-Wiki`가 제안하는 versioned domain definition 초안입니다.
 
+## v2 Summary
+
+v2에서 의도적으로 유지한 것:
+
+- shared fact minimalism
+- WorkNet 중심의 first fact source
+- `job_posting`, `company`, `role` 중심 canonical surface
+
+v2에서 명시적으로 추가한 것:
+
+- interpretation family/kind taxonomy
+- training/news source expansion 기준
+- evidence policy
+- quality examples and prompt guidance
+
+즉 v2는 "더 많은 fact"보다 "더 명시적인 reusable insight grammar"를 우선합니다.
+
 ## Canonical Concepts
 
-현재 v1에서 canonical Fact 후보로 승격하는 개념은 아래 3개입니다.
+현재 v2에서 canonical Fact 후보로 승격하는 개념은 아래 3개이며, 이 surface는 v1과 동일합니다.
 
 - `job_posting`
   - source-backed hiring opportunity
@@ -37,7 +58,7 @@ WorkNet 기반 첫 mapper 작업이 바로 붙을 수 있을 정도의 최소 se
 - `role`
   - hiring role or occupation
 
-현재 v1에서 canonical Relation 후보로 승격하는 개념은 아래 2개입니다.
+현재 v2에서 canonical Relation 후보로 승격하는 개념은 아래 2개이며, 이 surface는 v1과 동일합니다.
 
 - `posted_by`
   - `job_posting -> company`

--- a/docs/domain/recruiting-interpretation-grammar.md
+++ b/docs/domain/recruiting-interpretation-grammar.md
@@ -1,0 +1,216 @@
+---
+status: draft
+---
+
+# Recruiting Interpretation Grammar
+
+## Status
+
+Draft.
+
+이 문서는 `Jobs-Wiki`가 소유하는 recruiting interpretation grammar v2 초안입니다.
+canonical shared runtime과 governance는 `StrataWiki`가 소유하지만,
+어떤 recruiting insight family/kind를 인정할지는 `Jobs-Wiki`가 domain artifact로 제안합니다.
+
+## Purpose
+
+- recruiting shared layer를 무겁게 만들지 않으면서 reusable insight grammar를 명시합니다.
+- fact 최소주의와 interpretation 재사용성 사이의 경계를 문서와 artifact로 함께 설명합니다.
+- training/news source가 recruiting insight에 어떻게 기여할 수 있는지 기준을 정합니다.
+
+현재 source of truth artifact:
+
+- [packages/domain-packs/recruiting/v2.json](../../packages/domain-packs/recruiting/v2.json)
+
+## Design Rules
+
+- family는 page template가 아니라 반복 가능한 recruiting 질문 공간입니다.
+- kind는 family 안의 reviewable claim shape 입니다.
+- 새로운 insight 수요가 생겨도 먼저 interpretation kind로 수용할 수 있는지 검토하고, 그 다음에 fact 승격을 검토합니다.
+- training/news는 supporting interpretation source가 될 수 있지만, recruiting pack v2에서 곧바로 recruiting fact가 되지는 않습니다.
+- `Jobs-Wiki`는 grammar를 제안하고, `StrataWiki`는 등록/활성화/enforcement를 소유합니다.
+
+## Fact Boundary
+
+v2는 v1의 최소 fact surface를 유지합니다.
+
+- promoted entity: `job_posting`, `company`, `role`
+- promoted relation: `posted_by`, `for_role`
+- retained attribute:
+  - `job_posting.location_text`
+  - `job_posting.requirements_text`
+  - `job_posting.selection_process_text`
+
+즉 v2의 핵심 변화는 fact 확장이 아니라 interpretation grammar 명시화입니다.
+
+## Family Taxonomy
+
+### `market_trends`
+
+용도:
+
+- role, company, market segment 기준의 반복적인 hiring signal을 설명합니다.
+
+대표 kind:
+
+- `hiring_demand_shift`
+- `skill_demand_shift`
+- `company_hiring_pattern`
+- `location_shift`
+
+좋은 질문 예:
+
+- 특정 role segment의 수요가 최근 강해지고 있는가
+- 특정 회사군이 반복적으로 어떤 자격을 요구하는가
+
+### `opportunity_landscape`
+
+용도:
+
+- 지금 어디에 actionable opportunity가 있는지 shared하게 요약합니다.
+
+대표 kind:
+
+- `regional_opportunity_summary`
+- `company_opportunity_summary`
+- `role_opportunity_summary`
+- `training_pathway_signal`
+
+좋은 질문 예:
+
+- 특정 지역/직무 조합에서 현재 기회가 실제로 얼마나 보이는가
+- training 공급이 해당 기회 접근성을 보강하는가
+
+### `readiness_risks`
+
+용도:
+
+- recurring barrier, qualification gap, transition friction을 설명합니다.
+
+대표 kind:
+
+- `qualification_gap`
+- `competition_pressure`
+- `credential_requirement`
+- `transition_risk`
+
+좋은 질문 예:
+
+- 어떤 요구 조건이 반복적으로 진입 장벽이 되는가
+- role transition에서 어떤 준비 부족이 가장 자주 드러나는가
+
+### `source_health`
+
+용도:
+
+- shared interpretation 자체의 신뢰 범위를 설명합니다.
+
+대표 kind:
+
+- `coverage_gap`
+- `staleness_notice`
+- `source_conflict`
+
+좋은 질문 예:
+
+- 특정 segment가 한 source에 과도하게 치우쳐 있지 않은가
+- 최근 증거가 충분히 새롭고 일관적인가
+
+## Subject Guidance
+
+우선 subject는 아래 축을 권장합니다.
+
+- `role`
+- `company`
+- `job_posting`
+- `market_segment`
+- `training_path`
+- `source_set`
+
+원칙:
+
+- `role`, `company`, `job_posting`은 pack fact와 직접 연결됩니다.
+- `market_segment`, `training_path`, `source_set`은 lightweight derived subject이지만 설명 가능한 key여야 합니다.
+- derived subject를 도입해도 shared layer를 별도 heavy ontology로 확장하지 않습니다.
+
+## Source Expansion
+
+### WorkNet
+
+- 역할: `primary_fact_source`
+- 현재 recruiting pack v2의 사실상 기준 source
+- fact와 interpretation 둘 다의 주 증거로 사용
+
+### Training
+
+- 역할: `supporting_interpretation_source`
+- course/provider identity가 안정적이고, role access를 설명하는 경우에만 recruiting insight 근거로 사용
+- 기본 처리: pathway, readiness, opportunity kind의 supporting evidence
+- 비목표: recruiting pack v2에서 training course 자체를 recruiting fact로 승격
+
+### News
+
+- 역할: `supporting_interpretation_source`
+- attributable하고 time-bounded하며 recruiting relevance가 분명한 기사만 사용
+- 기본 처리: company/market trend를 보강하거나 source conflict를 설명하는 증거
+- 비목표: article 자체를 recruiting fact로 승격
+
+## Evidence Policy
+
+공통 규칙:
+
+- interpretation은 traceable evidence를 가져야 합니다.
+- market-wide claim은 단일 anecdote로 publish하지 않습니다.
+- training/news는 core recruiting evidence를 대체하지 않고 보강합니다.
+
+family별 기본선:
+
+- `market_trends`
+  - 최소 evidence 2개
+  - time-bounded evidence 필요
+- `opportunity_landscape`
+  - 최소 evidence 2개
+  - current open signal 필요
+- `readiness_risks`
+  - 최소 evidence 2개
+  - barrier-specific support 필요
+- `source_health`
+  - 최소 evidence 1개
+  - source metadata 필요
+
+## Quality Examples
+
+좋은 예:
+
+- "Recent backend postings repeatedly combine API integration and production AI operation requirements."
+  - narrow하고 반복 신호를 설명하며, reusable insight로 읽힙니다.
+- "This segment is currently dominated by one provider, so demand intensity should be treated as provisional."
+  - 해석 자체의 신뢰 범위를 드러내어 shared layer를 과신하지 않게 합니다.
+
+나쁜 예:
+
+- "One open posting proves the market is booming."
+  - 단일 사례를 trend로 과장합니다.
+- "Everyone should learn Kubernetes now."
+  - recruiting evidence에 anchored 되지 않은 generic advice입니다.
+
+## Prompt Direction
+
+- scoped claim을 우선하고 과장된 시장 서사를 피합니다.
+- subject와 change를 먼저 밝히고 generic recommendation으로 흘리지 않습니다.
+- coverage bias, freshness, disagreement를 숨기지 않습니다.
+- training/news를 쓰더라도 새 recruiting fact를 발명하는 지름길로 쓰지 않습니다.
+- 개인화 추천이 아니라 shared reusable insight를 우선합니다.
+
+## Ownership Boundary
+
+- `Jobs-Wiki`
+  - recruiting interpretation family/kind grammar 제안
+  - source expansion 기준 제안
+  - quality examples와 prompt guidance 제안
+- `StrataWiki`
+  - pack registration / activation
+  - runtime validation / enforcement
+  - interpretation lifecycle / storage / snapshot governance
+
+즉 grammar는 domain-owned artifact이고, lifecycle은 runtime-owned contract입니다.

--- a/docs/domain/recruitments.md
+++ b/docs/domain/recruitments.md
@@ -19,13 +19,13 @@ Draft
 
 ## Current Pack Baseline
 
-2026-04-18 기준 recruiting canonical fact baseline은
+2026-04-22 기준 recruiting canonical baseline은
 [Recruiting Domain Pack](./recruiting-domain-pack.md)
 문서와
-[packages/domain-packs/recruiting/v1.json](../../packages/domain-packs/recruiting/v1.json)
+[packages/domain-packs/recruiting/v2.json](../../packages/domain-packs/recruiting/v2.json)
 artifact에 정리되어 있습니다.
 
-현재 v1에서 pack이 승격하는 canonical entity / relation은 아래입니다.
+현재 v2에서 pack이 승격하는 canonical entity / relation은 아래이며, fact surface는 v1과 동일합니다.
 
 - `job_posting`
 - `company`
@@ -33,14 +33,18 @@ artifact에 정리되어 있습니다.
 - `posted_by`
 - `for_role`
 
-현재 v1에서 pack이 entity로 승격하지 않고 `job_posting` attribute로 남기는 항목은 아래입니다.
+현재 v2에서 pack이 entity로 승격하지 않고 `job_posting` attribute로 남기는 항목은 아래입니다.
 
 - `location`
 - `skill`
 - `selection_step`
 
+또한 v2는 별도 interpretation grammar artifact를 같이 둡니다.
+
+- [Recruiting Interpretation Grammar](./recruiting-interpretation-grammar.md)
+
 즉 이 문서는 recruitment read model / public-resource 후보를 설명하고,
-pack 자체의 canonical fact scope와 identity hint 결정은 별도 domain-pack 문서를 source of truth로 둡니다.
+pack 자체의 canonical fact scope, identity hint, interpretation grammar 결정은 별도 domain-pack 문서를 source of truth로 둡니다.
 
 ## Stable Concepts
 

--- a/docs/domain/training.md
+++ b/docs/domain/training.md
@@ -10,6 +10,10 @@ Draft
 
 국민내일배움카드, 사업주훈련, 컨소시엄, 일학습병행처럼 구조가 유사한 여러 훈련 API를 내부적으로 어떤 공통 모델로 다룰지 정리합니다.
 
+현재 recruiting pack v2 기준에서 training source는 recruiting shared fact를 직접 늘리는 primary source가 아니라,
+`training_pathway_signal`, `qualification_gap`, `transition_risk` 같은 recruiting interpretation을 보강하는
+supporting interpretation source로 먼저 취급합니다.
+
 ## Stable Concepts
 
 - `TrainingSummary`

--- a/docs/product/llm-requirements-baseline.md
+++ b/docs/product/llm-requirements-baseline.md
@@ -14,6 +14,7 @@ LLM이 어떤 역할을 맡아야 하는지 사용자-facing 기준으로 고정
 - LLM은 workspace 안의 지식을 읽고 구조화하는 계층이다
 - LLM은 personal layer를 구성하는 wiki assistant다
 - personal layer의 작업은 절대로 상위 layer로 전파되면 안 된다
+- shared `Fact`/`Interpretation`은 personal workspace를 돕는 lightweight substrate다
 
 ## Product Position
 
@@ -22,7 +23,7 @@ LLM이 어떤 역할을 맡아야 하는지 사용자-facing 기준으로 고정
 LLM은 아래를 담당해야 합니다.
 
 - 사용자의 자료를 읽고 구조화한다
-- shared knowledge를 참고해 personal knowledge를 재구성한다
+- shared substrate를 참고해 personal knowledge를 재구성한다
 - 사용자 맥락에 맞는 answer, note, wiki document를 만든다
 
 즉 제품 관점에서의 LLM 역할은 아래처럼 봅니다.
@@ -30,6 +31,9 @@ LLM은 아래를 담당해야 합니다.
 - `Fact`의 직접 작성자: 아님
 - `Interpretation`의 주요 생성자: 맞음
 - `Personal` answer와 personal wiki의 주요 작성자: 맞음
+
+추가로, shared layer의 역할은 완결형 공용 지식 공간이라기보다
+personal wiki를 grounding 하는 reusable context layer로 이해하는 것이 맞습니다.
 
 ## Layer and Directory Model
 
@@ -44,6 +48,13 @@ LLM은 아래를 담당해야 합니다.
 - `personal/wiki/`
   - LLM이 raw 문서를 재가공해 만든 personal wiki 문서
   - 요약, 재작성, link/relation이 붙은 정리 문서
+
+저장 관점의 원칙:
+
+- `shared`의 canonical payload는 StrataWiki DB에 있음
+- `shared` markdown은 rendered view임
+- `personal/*`의 canonical body는 markdown 파일임
+- personal DB metadata는 registry 용도에 머무름
 
 핵심 규칙:
 
@@ -105,7 +116,7 @@ LLM answer는 grounding 없이 노출되면 안 됩니다.
 
 ## L4. Shared Interpretation Generation
 
-LLM은 shared knowledge layer에서 reusable interpretation을 생성할 수 있어야 합니다.
+LLM은 shared layer에서 reusable interpretation을 생성할 수 있어야 합니다.
 
 필수 요구사항:
 
@@ -113,6 +124,7 @@ LLM은 shared knowledge layer에서 reusable interpretation을 생성할 수 있
 - interpretation은 evidence-backed, revisable, versioned state를 가져야 합니다.
 - interpretation은 proposal -> validation -> publish lifecycle을 거쳐야 합니다.
 - rendered shared page는 interpretation record와 분리되어야 합니다.
+- interpretation은 무거운 완결형 shared brain이 아니라 reusable shared insight로 유지되는 편이 맞습니다.
 
 현재 제품 해석:
 
@@ -146,6 +158,7 @@ LLM은 personal/raw 문서를 personal/wiki 문서로 재구성할 수 있어야
 - 결과는 항상 `personal/wiki`에 저장되어야 합니다.
 - 원문은 `personal/raw`에 남아야 합니다.
 - 결과는 personal artifact일 뿐, shared나 interpretation layer를 직접 수정하지 않습니다.
+- personal 문서의 canonical body 는 markdown 으로 유지하는 편이 맞습니다.
 
 ## L7. Retrieval Discipline
 
@@ -158,6 +171,7 @@ LLM은 필요한 모든 것을 자유롭게 읽는 방식이 아니라,
 - 일반 질의는 `Personal -> Interpretation -> Fact` 순서로 retrieval하는 것이 기본이어야 합니다.
 - exploratory retrieval은 open-ended request에서만 허용해야 합니다.
 - exploratory retrieval은 read-only, scope-aware, hop-limited, result-limited여야 합니다.
+- graph expansion은 support surface일 뿐, dense graph-first retrieval이 기본값이어서는 안 됩니다.
 
 ## L8. Authority Boundary
 

--- a/packages/domain-packs/README.md
+++ b/packages/domain-packs/README.md
@@ -4,11 +4,16 @@
 
 현재 포함된 artifact:
 
+- `recruiting/v2.json`
+  - current recruiting pack v2 draft
+  - keeps the minimal shared fact surface from v1
+  - adds interpretation grammar, source expansion policy, and evidence/quality guidance
 - `recruiting/v1.json`
-  - WorkNet `open_recruitment` 기준 첫 recruiting pack draft
+  - historical WorkNet `open_recruitment` 기준 첫 recruiting pack draft
   - canonical entity: `job_posting`, `company`, `role`
   - canonical relation: `posted_by`, `for_role`
 
 관련 공식 문서:
 
 - [docs/domain/recruiting-domain-pack.md](../../docs/domain/recruiting-domain-pack.md)
+- [docs/domain/recruiting-interpretation-grammar.md](../../docs/domain/recruiting-interpretation-grammar.md)

--- a/packages/domain-packs/recruiting/mapper.ts
+++ b/packages/domain-packs/recruiting/mapper.ts
@@ -5,14 +5,14 @@ import type {
 } from "../../integrations/worknet/src/recruiting.ts";
 
 export const RECRUITING_DOMAIN = "recruiting";
-export const RECRUITING_PACK_VERSION = "2026-04-18";
+export const RECRUITING_PACK_VERSION = "2026-04-22";
 export const WORKNET_RECRUITING_PROPOSAL_PRODUCER =
-  "jobs-wiki.worknet.open_recruitment.mapper/v1";
+  "jobs-wiki.worknet.open_recruitment.mapper/v2";
 export const WORKNET_RECRUITING_EVIDENCE_CONNECTOR = "worknet.open_recruitment";
 
-export const WORKNET_RECRUITING_V1_AMBIGUOUS_FIELDS = ["posting.notes"] as const;
+export const WORKNET_RECRUITING_V2_AMBIGUOUS_FIELDS = ["posting.notes"] as const;
 
-export const WORKNET_RECRUITING_V1_OMITTED_FIELDS = [
+export const WORKNET_RECRUITING_V2_OMITTED_FIELDS = [
   "posting.applicationMethod",
   "posting.requiredDocuments",
   "posting.inquiry",

--- a/packages/domain-packs/recruiting/v2.json
+++ b/packages/domain-packs/recruiting/v2.json
@@ -1,0 +1,656 @@
+{
+  "manifest": {
+    "domain": "recruiting",
+    "packVersion": "2026-04-22",
+    "status": "draft",
+    "supersedesPackVersion": "2026-04-18",
+    "compatibility": {
+      "minStrataWikiVersion": "0.2.0"
+    },
+    "owner": {
+      "system": "jobs-wiki",
+      "team": "career-knowledge"
+    },
+    "sourceProfiles": [
+      "worknet.open_recruitment"
+    ],
+    "adjacentArtifacts": [
+      "docs/domain/recruiting-domain-pack.md",
+      "docs/domain/recruiting-interpretation-grammar.md"
+    ]
+  },
+  "proposalSurface": {
+    "accepts": {
+      "factProposal": true,
+      "relationProposal": true
+    },
+    "strictUnknownAttributes": true,
+    "batchMode": "atomic"
+  },
+  "entityTypes": {
+    "job_posting": {
+      "description": "A source-backed hiring opportunity that remains source-scoped in v2.",
+      "requiredAttributes": [
+        "title"
+      ],
+      "attributes": {
+        "title": {
+          "type": "string",
+          "description": "Human-readable posting title."
+        },
+        "summary": {
+          "type": "markdown",
+          "description": "Primary posting summary or recruiting description."
+        },
+        "employment_type": {
+          "type": "string",
+          "description": "Employment category text."
+        },
+        "opens_at": {
+          "type": "datetime",
+          "description": "Opening timestamp when available."
+        },
+        "closes_at": {
+          "type": "datetime",
+          "description": "Closing timestamp when available."
+        },
+        "source_url": {
+          "type": "url",
+          "description": "Desktop source page URL."
+        },
+        "mobile_source_url": {
+          "type": "url",
+          "description": "Mobile source page URL."
+        },
+        "location_text": {
+          "type": "string",
+          "description": "Posting-local work location text kept as an attribute in v2."
+        },
+        "requirements_text": {
+          "type": "markdown",
+          "description": "Free-form qualification text that is not promoted to skill facts in v2."
+        },
+        "selection_process_text": {
+          "type": "markdown",
+          "description": "Free-form selection process text kept as an attribute in v2."
+        }
+      },
+      "identity": {
+        "mode": "hint_priority",
+        "strategies": [
+          {
+            "hint": "source_id",
+            "prefix": "job_posting",
+            "normalization": [
+              "trim"
+            ],
+            "description": "Use the provider-scoped posting identifier. v2 still does not merge postings across providers."
+          }
+        ],
+        "fallback": "reject"
+      },
+      "mergePolicy": {
+        "mode": "upsert",
+        "conflictStrategy": "prefer_newer_source"
+      }
+    },
+    "company": {
+      "description": "The hiring organization linked from a job posting.",
+      "requiredAttributes": [
+        "name"
+      ],
+      "attributes": {
+        "name": {
+          "type": "string",
+          "description": "Display name for the organization."
+        },
+        "normalized_name": {
+          "type": "string",
+          "description": "Name normalized for fallback identity matching."
+        },
+        "company_type": {
+          "type": "string",
+          "description": "Organization classification text."
+        },
+        "homepage_url": {
+          "type": "url",
+          "description": "Canonical homepage or company page."
+        },
+        "business_number": {
+          "type": "string",
+          "description": "Registration number when available."
+        },
+        "summary": {
+          "type": "markdown",
+          "description": "Short company introduction."
+        },
+        "description": {
+          "type": "markdown",
+          "description": "Longer company profile text."
+        },
+        "main_business": {
+          "type": "string",
+          "description": "Primary business description."
+        }
+      },
+      "identity": {
+        "mode": "hint_priority",
+        "strategies": [
+          {
+            "hint": "external_id",
+            "prefix": "company",
+            "normalization": [
+              "trim"
+            ],
+            "description": "Preferred when a source-specific company identifier is available, such as WorkNet empCoNo."
+          },
+          {
+            "hint": "business_number",
+            "prefix": "company",
+            "normalization": [
+              "digits_only"
+            ],
+            "description": "Cross-source fallback when a business registration number is available."
+          },
+          {
+            "hint": "normalized_name",
+            "prefix": "company",
+            "normalization": [
+              "trim",
+              "lowercase",
+              "collapse_whitespace"
+            ],
+            "description": "Last-resort fallback when no stronger company identifier exists."
+          }
+        ],
+        "fallback": "manual_review"
+      },
+      "mergePolicy": {
+        "mode": "upsert",
+        "conflictStrategy": "manual_review"
+      }
+    },
+    "role": {
+      "description": "The role or occupation targeted by a job posting.",
+      "requiredAttributes": [
+        "display_name"
+      ],
+      "attributes": {
+        "display_name": {
+          "type": "string",
+          "description": "Human-readable role label."
+        },
+        "normalized_name": {
+          "type": "string",
+          "description": "Role label normalized for fallback identity matching."
+        },
+        "source_code": {
+          "type": "string",
+          "description": "Provider role or occupation code when available."
+        }
+      },
+      "identity": {
+        "mode": "hint_priority",
+        "strategies": [
+          {
+            "hint": "external_id",
+            "prefix": "role",
+            "normalization": [
+              "trim"
+            ],
+            "description": "Preferred when a provider emits a stable occupation code, such as WorkNet jobsCode."
+          },
+          {
+            "hint": "normalized_name",
+            "prefix": "role",
+            "normalization": [
+              "trim",
+              "lowercase",
+              "collapse_whitespace"
+            ],
+            "description": "Fallback when only a role label is present."
+          }
+        ],
+        "fallback": "reject"
+      },
+      "mergePolicy": {
+        "mode": "upsert",
+        "conflictStrategy": "prefer_existing"
+      }
+    }
+  },
+  "relationTypes": {
+    "posted_by": {
+      "description": "Connects a job posting to the company that published or owns the recruitment.",
+      "fromEntityTypes": [
+        "job_posting"
+      ],
+      "toEntityTypes": [
+        "company"
+      ],
+      "cardinality": "many_to_many",
+      "evidencePolicy": "required"
+    },
+    "for_role": {
+      "description": "Connects a job posting to a target role or occupation.",
+      "fromEntityTypes": [
+        "job_posting"
+      ],
+      "toEntityTypes": [
+        "role"
+      ],
+      "cardinality": "many_to_many",
+      "evidencePolicy": "required"
+    }
+  },
+  "projectionHints": {
+    "defaultTitleAttribute": {
+      "job_posting": "title",
+      "company": "name",
+      "role": "display_name"
+    },
+    "searchableAttributes": {
+      "job_posting": [
+        "title",
+        "summary",
+        "location_text",
+        "requirements_text"
+      ],
+      "company": [
+        "name",
+        "summary",
+        "main_business"
+      ],
+      "role": [
+        "display_name"
+      ]
+    },
+    "summaryAttributes": {
+      "job_posting": [
+        "summary",
+        "selection_process_text"
+      ],
+      "company": [
+        "summary",
+        "description"
+      ],
+      "role": []
+    },
+    "temporalAttributes": {
+      "job_posting": {
+        "start": "opens_at",
+        "end": "closes_at"
+      }
+    },
+    "defaultFamilyByEntityType": {
+      "job_posting": "opportunity",
+      "company": "company",
+      "role": "role"
+    }
+  },
+  "factScopePolicy": {
+    "principles": [
+      "Keep shared facts minimal and reusable; do not make shared recruiting semantics depend on UI-shaped fields.",
+      "Prefer richer interpretation grammar over adding brittle first-class facts too early.",
+      "Training and news may support recruiting insight without becoming recruiting facts in v2."
+    ],
+    "promotedEntities": [
+      "job_posting",
+      "company",
+      "role"
+    ],
+    "promotedRelations": [
+      "posted_by",
+      "for_role"
+    ],
+    "retainedAttributes": [
+      {
+        "concept": "location",
+        "entityType": "job_posting",
+        "attribute": "location_text",
+        "reason": "Current recruiting sources still emit posting-local free text more often than reusable geography identity."
+      },
+      {
+        "concept": "skill_signal",
+        "entityType": "job_posting",
+        "attribute": "requirements_text",
+        "reason": "Qualification prose is preserved, but v2 still avoids promoting unstable skills into canonical shared facts."
+      },
+      {
+        "concept": "selection_step",
+        "entityType": "job_posting",
+        "attribute": "selection_process_text",
+        "reason": "Selection stages are usually posting-local and noisy, so v2 keeps them as evidence-friendly text."
+      }
+    ],
+    "promotionGates": [
+      "cross-source reuse value must be explicit",
+      "deterministic identity or reviewable fallback must exist",
+      "evidence must be traceable to source pointer or fact support link",
+      "the promoted concept must improve shared interpretation reuse more than it increases runtime governance cost"
+    ]
+  },
+  "interpretationGrammar": {
+    "version": "recruiting-interpretation-grammar/v2",
+    "principles": [
+      "Family groups a reusable recruiting question space, not a page template.",
+      "Kind names a reviewable claim shape inside the family.",
+      "Subjects may be canonical facts or lightweight derived segments, but derived subjects must remain explainable.",
+      "Interpretations should reuse the existing fact surface before asking for new fact entities."
+    ],
+    "subjectTypes": {
+      "role": {
+        "description": "Canonical role subject backed by the recruiting pack."
+      },
+      "company": {
+        "description": "Canonical company subject backed by the recruiting pack."
+      },
+      "job_posting": {
+        "description": "Source-scoped posting subject used for narrow opportunity synthesis, not long-lived market claims."
+      },
+      "market_segment": {
+        "description": "Derived segment such as role plus region, seniority, or company segment."
+      },
+      "training_path": {
+        "description": "Derived role-to-training pathway key used when training sources support recruiting interpretation."
+      },
+      "source_set": {
+        "description": "Coverage and staleness subject representing one or more source profiles."
+      }
+    },
+    "families": {
+      "market_trends": {
+        "description": "Reusable claims about hiring demand, company behavior, compensation, or geographic shifts.",
+        "subjectTypes": [
+          "role",
+          "company",
+          "market_segment"
+        ],
+        "kinds": {
+          "hiring_demand_shift": {
+            "description": "Demand for a role or market segment is rising, stable, or cooling.",
+            "preferredEvidence": [
+              "job_posting",
+              "role",
+              "company"
+            ]
+          },
+          "skill_demand_shift": {
+            "description": "A repeated qualification or skill signal is strengthening or weakening in a role segment.",
+            "preferredEvidence": [
+              "job_posting",
+              "role"
+            ]
+          },
+          "company_hiring_pattern": {
+            "description": "A company or company segment repeats a recognizable hiring behavior.",
+            "preferredEvidence": [
+              "job_posting",
+              "company"
+            ]
+          },
+          "location_shift": {
+            "description": "A location preference or concentration pattern is emerging for a role or segment.",
+            "preferredEvidence": [
+              "job_posting",
+              "company"
+            ]
+          }
+        }
+      },
+      "opportunity_landscape": {
+        "description": "Shared summaries of where opportunities exist now and what makes them actionable.",
+        "subjectTypes": [
+          "role",
+          "company",
+          "market_segment",
+          "training_path"
+        ],
+        "kinds": {
+          "regional_opportunity_summary": {
+            "description": "Summarizes opportunity density and access conditions for a region-segment combination.",
+            "preferredEvidence": [
+              "job_posting",
+              "company",
+              "role"
+            ]
+          },
+          "company_opportunity_summary": {
+            "description": "Summarizes the current hiring surface for one company or company segment.",
+            "preferredEvidence": [
+              "job_posting",
+              "company"
+            ]
+          },
+          "role_opportunity_summary": {
+            "description": "Summarizes the current opening landscape for a role across sources.",
+            "preferredEvidence": [
+              "job_posting",
+              "role"
+            ]
+          },
+          "training_pathway_signal": {
+            "description": "Explains when training supply appears to support access to a role or transition path.",
+            "preferredEvidence": [
+              "training_course",
+              "job_posting",
+              "role"
+            ]
+          }
+        }
+      },
+      "readiness_risks": {
+        "description": "Reusable claims about access friction, qualification gaps, or transition difficulty.",
+        "subjectTypes": [
+          "role",
+          "market_segment",
+          "training_path"
+        ],
+        "kinds": {
+          "qualification_gap": {
+            "description": "A recurring qualification pattern blocks access to a target opportunity cluster.",
+            "preferredEvidence": [
+              "job_posting",
+              "role",
+              "training_course"
+            ]
+          },
+          "competition_pressure": {
+            "description": "Competition or expectation density appears high for the target segment.",
+            "preferredEvidence": [
+              "job_posting",
+              "company"
+            ]
+          },
+          "credential_requirement": {
+            "description": "Specific credentials, experience thresholds, or certifications are repeatedly demanded.",
+            "preferredEvidence": [
+              "job_posting",
+              "role",
+              "training_course"
+            ]
+          },
+          "transition_risk": {
+            "description": "A role transition has recurring barriers that should be made explicit.",
+            "preferredEvidence": [
+              "job_posting",
+              "role",
+              "training_course"
+            ]
+          }
+        }
+      },
+      "source_health": {
+        "description": "Coverage and evidence-quality summaries that keep shared interpretation claims reviewable.",
+        "subjectTypes": [
+          "source_set",
+          "market_segment",
+          "company"
+        ],
+        "kinds": {
+          "coverage_gap": {
+            "description": "A recruiting view is under-covered or skewed because source coverage is thin.",
+            "preferredEvidence": [
+              "source_pointer",
+              "job_posting"
+            ]
+          },
+          "staleness_notice": {
+            "description": "A claim or segment should be treated carefully because input evidence is aging.",
+            "preferredEvidence": [
+              "source_pointer",
+              "job_posting"
+            ]
+          },
+          "source_conflict": {
+            "description": "Source families disagree materially on the same recruiting claim.",
+            "preferredEvidence": [
+              "source_pointer",
+              "job_posting",
+              "news_article"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "sourceExpansionPolicy": {
+    "principles": [
+      "New source families should first enrich interpretation evidence before expanding recruiting fact scope.",
+      "Jobs-Wiki owns source routing and semantic framing; StrataWiki owns runtime enforcement once the artifact is registered.",
+      "Training and news sources may be admitted as supporting interpretation inputs without turning the shared recruiting layer into a general content store."
+    ],
+    "sourceFamilies": {
+      "worknet.open_recruitment": {
+        "role": "primary_fact_source",
+        "supportsFacts": [
+          "job_posting",
+          "company",
+          "role",
+          "posted_by",
+          "for_role"
+        ],
+        "supportsInterpretationFamilies": [
+          "market_trends",
+          "opportunity_landscape",
+          "readiness_risks",
+          "source_health"
+        ]
+      },
+      "training.catalog": {
+        "role": "supporting_interpretation_source",
+        "admissionCriteria": [
+          "stable course and provider identity are available",
+          "course timing or curriculum helps explain access to a recruiting segment",
+          "the signal can be cited without promoting course facts into the recruiting pack"
+        ],
+        "defaultHandling": "Use as evidence for pathway, readiness, or opportunity claims until a separate training domain pack is mature.",
+        "supportsInterpretationFamilies": [
+          "opportunity_landscape",
+          "readiness_risks",
+          "source_health"
+        ]
+      },
+      "news.article": {
+        "role": "supporting_interpretation_source",
+        "admissionCriteria": [
+          "the article is attributable and time-bounded",
+          "the claim is recruiting-relevant rather than generic corporate promotion",
+          "the article strengthens or qualifies an existing recruiting interpretation family"
+        ],
+        "defaultHandling": "Use as company or market evidence only; do not promote article facts into recruiting pack v2.",
+        "supportsInterpretationFamilies": [
+          "market_trends",
+          "source_health"
+        ]
+      }
+    }
+  },
+  "evidencePolicy": {
+    "sharedRules": [
+      "Every interpretation should cite traceable evidence, ideally at fact or source-pointer granularity.",
+      "Single anecdotal records should not be published as market-wide claims.",
+      "News and training evidence may qualify or enrich a claim, but should not replace core recruiting evidence when the claim is about hiring demand."
+    ],
+    "familyRequirements": {
+      "market_trends": {
+        "minimumEvidenceItems": 2,
+        "requiresTimeBoundEvidence": true,
+        "preferredEvidenceMix": [
+          "job_posting",
+          "role",
+          "company"
+        ]
+      },
+      "opportunity_landscape": {
+        "minimumEvidenceItems": 2,
+        "requiresCurrentOpenSignal": true,
+        "preferredEvidenceMix": [
+          "job_posting",
+          "company",
+          "role"
+        ]
+      },
+      "readiness_risks": {
+        "minimumEvidenceItems": 2,
+        "requiresBarrierSpecificSupport": true,
+        "preferredEvidenceMix": [
+          "job_posting",
+          "role",
+          "training_course"
+        ]
+      },
+      "source_health": {
+        "minimumEvidenceItems": 1,
+        "requiresSourceMetadata": true,
+        "preferredEvidenceMix": [
+          "source_pointer",
+          "job_posting"
+        ]
+      }
+    }
+  },
+  "qualityGuidance": {
+    "goodExamples": [
+      {
+        "family": "market_trends",
+        "kind": "skill_demand_shift",
+        "example": "Recent backend postings repeatedly combine API integration and production AI operation requirements.",
+        "why": "The claim is narrow, evidence-backed, and explains a reusable hiring signal."
+      },
+      {
+        "family": "opportunity_landscape",
+        "kind": "training_pathway_signal",
+        "example": "Short applied data-engineering bootcamps are appearing alongside junior platform openings, suggesting a plausible on-ramp.",
+        "why": "The claim connects recruiting and training without pretending the training catalog is itself recruiting fact truth."
+      },
+      {
+        "family": "source_health",
+        "kind": "coverage_gap",
+        "example": "This segment is currently dominated by one provider, so demand intensity should be treated as provisional.",
+        "why": "The interpretation tells consumers how much confidence to place in the shared layer."
+      }
+    ],
+    "badExamples": [
+      {
+        "family": "market_trends",
+        "kind": "hiring_demand_shift",
+        "example": "One open posting proves the market is booming.",
+        "why": "A single posting is insufficient for a reusable market claim."
+      },
+      {
+        "family": "readiness_risks",
+        "kind": "qualification_gap",
+        "example": "Everyone should learn Kubernetes now.",
+        "why": "The statement is generic advice, not a scoped and evidenced recruiting interpretation."
+      }
+    ],
+    "promptGuidelines": [
+      "Prefer scoped claims over sweeping market narratives.",
+      "Name the target subject and what changed, not just a generic recommendation.",
+      "Call out uncertainty, skew, or thin coverage when evidence is weak.",
+      "Use training or news as supporting context, not as a shortcut for inventing new recruiting facts.",
+      "Keep outputs reusable by multiple users rather than profile-personalized."
+    ]
+  }
+}

--- a/packages/integrations/stratawiki-http/client.js
+++ b/packages/integrations/stratawiki-http/client.js
@@ -14,6 +14,10 @@ function compactObject(value) {
   )
 }
 
+function formatOpportunityCursor(offset) {
+  return `cursor_${String(offset).padStart(3, "0")}`
+}
+
 function buildQueryString(query = {}) {
   const params = new URLSearchParams()
 
@@ -256,6 +260,86 @@ export function createStratawikiHttpClient({
       const response = await request({
         method: "GET",
         path: `/api/v1/tools/${encodeURIComponent(name)}`,
+        requestId,
+      })
+      return response.result
+    },
+    async getWorkspaceSummary({
+      domain,
+      scope = "shared",
+      profileId,
+      requestId,
+    } = {}) {
+      const response = await request({
+        method: "GET",
+        path: "/api/v1/workspace-summary",
+        query: {
+          domain,
+          scope,
+          profileId,
+        },
+        requestId,
+      })
+      return response.result
+    },
+    async listOpportunities({
+      domain,
+      scope = "shared",
+      query = {},
+      requestId,
+    } = {}) {
+      const cursor =
+        query?.cursor ??
+        (query?.cursorOffset !== undefined
+          ? formatOpportunityCursor(query.cursorOffset)
+          : undefined)
+      const response = await request({
+        method: "GET",
+        path: "/api/v1/opportunities",
+        query: {
+          domain,
+          scope,
+          limit: query?.limit,
+          cursor,
+          status: query?.status,
+          closingWithinDays: query?.closingWithinDays,
+        },
+        requestId,
+      })
+      return response.result
+    },
+    async getOpportunity({
+      domain,
+      scope = "shared",
+      opportunityId,
+      requestId,
+    } = {}) {
+      const response = await request({
+        method: "GET",
+        path: `/api/v1/opportunities/${encodeURIComponent(opportunityId)}`,
+        query: {
+          domain,
+          scope,
+        },
+        requestId,
+      })
+      return response.result
+    },
+    async getCalendar({
+      domain,
+      scope = "shared",
+      query = {},
+      requestId,
+    } = {}) {
+      const response = await request({
+        method: "GET",
+        path: "/api/v1/calendar",
+        query: {
+          domain,
+          scope,
+          from: query?.from,
+          to: query?.to,
+        },
         requestId,
       })
       return response.result

--- a/packages/integrations/stratawiki-http/client.js
+++ b/packages/integrations/stratawiki-http/client.js
@@ -14,6 +14,347 @@ function compactObject(value) {
   )
 }
 
+function normalizeScopedPayload(payload = {}) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return payload
+  }
+
+  const normalized = { ...payload }
+
+  if (normalized.tenant_id === undefined && payload.tenantId !== undefined) {
+    normalized.tenant_id = payload.tenantId
+  }
+
+  if (normalized.user_id === undefined && payload.userId !== undefined) {
+    normalized.user_id = payload.userId
+  }
+
+  if (normalized.profile_version === undefined && payload.profileVersion !== undefined) {
+    normalized.profile_version = payload.profileVersion
+  }
+
+  if (normalized.if_version === undefined && payload.ifVersion !== undefined) {
+    normalized.if_version = payload.ifVersion
+  }
+
+  delete normalized.tenantId
+  delete normalized.userId
+  delete normalized.profileVersion
+  delete normalized.ifVersion
+
+  return normalized
+}
+
+function normalizeWorkspacePathPayload(workspacePath) {
+  if (!workspacePath || typeof workspacePath !== "object" || Array.isArray(workspacePath)) {
+    return workspacePath
+  }
+
+  return compactObject({
+    section_id: workspacePath.section_id ?? workspacePath.sectionId,
+    segments: workspacePath.segments,
+    label: workspacePath.label,
+  })
+}
+
+function normalizeDocumentRefPayload(documentRef) {
+  if (!documentRef || typeof documentRef !== "object" || Array.isArray(documentRef)) {
+    return documentRef
+  }
+
+  const normalized = { ...documentRef }
+
+  if (normalized.document_id === undefined && documentRef.documentId !== undefined) {
+    normalized.document_id = documentRef.documentId
+  }
+
+  if (normalized.asset_refs === undefined && documentRef.assetRefs !== undefined) {
+    normalized.asset_refs = documentRef.assetRefs
+  }
+
+  delete normalized.documentId
+  delete normalized.assetRefs
+
+  return normalized
+}
+
+function normalizePersonalDocumentPayload(payload = {}) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return payload
+  }
+
+  const normalized = normalizeScopedPayload(payload)
+
+  if (normalized.body_markdown === undefined && payload.bodyMarkdown !== undefined) {
+    normalized.body_markdown = payload.bodyMarkdown
+  }
+
+  if (normalized.asset_refs === undefined && payload.assetRefs !== undefined) {
+    normalized.asset_refs = payload.assetRefs
+  }
+
+  if (normalized.workspace_path === undefined && payload.workspacePath !== undefined) {
+    normalized.workspace_path = normalizeWorkspacePathPayload(payload.workspacePath)
+  }
+
+  if (normalized.source_document_ref === undefined && payload.sourceDocumentRef !== undefined) {
+    normalized.source_document_ref = normalizeDocumentRefPayload(payload.sourceDocumentRef)
+  }
+
+  if (normalized.save_target === undefined && payload.saveTarget !== undefined) {
+    normalized.save_target = normalizeDocumentRefPayload(payload.saveTarget)
+  }
+
+  if (normalized.wiki_document_id === undefined && payload.wikiDocumentId !== undefined) {
+    normalized.wiki_document_id = payload.wikiDocumentId
+  }
+
+  if (
+    normalized.wiki_document_version === undefined &&
+    payload.wikiDocumentVersion !== undefined
+  ) {
+    normalized.wiki_document_version = payload.wikiDocumentVersion
+  }
+
+  if (normalized.model_profile === undefined && payload.modelProfile !== undefined) {
+    normalized.model_profile = payload.modelProfile
+  }
+
+  if (normalized.summary_style === undefined && payload.summaryStyle !== undefined) {
+    normalized.summary_style = payload.summaryStyle
+  }
+
+  if (normalized.rewrite_goal === undefined && payload.rewriteGoal !== undefined) {
+    normalized.rewrite_goal = payload.rewriteGoal
+  }
+
+  if (
+    normalized.structure_template === undefined &&
+    payload.structureTemplate !== undefined
+  ) {
+    normalized.structure_template = payload.structureTemplate
+  }
+
+  if (normalized.max_suggestions === undefined && payload.maxSuggestions !== undefined) {
+    normalized.max_suggestions = payload.maxSuggestions
+  }
+
+  delete normalized.bodyMarkdown
+  delete normalized.assetRefs
+  delete normalized.workspacePath
+  delete normalized.sourceDocumentRef
+  delete normalized.saveTarget
+  delete normalized.wikiDocumentId
+  delete normalized.wikiDocumentVersion
+  delete normalized.modelProfile
+  delete normalized.summaryStyle
+  delete normalized.rewriteGoal
+  delete normalized.structureTemplate
+  delete normalized.maxSuggestions
+
+  return normalized
+}
+
+function normalizePersonalAssetPayload(payload = {}) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return payload
+  }
+
+  const normalized = normalizeScopedPayload(payload)
+
+  if (normalized.asset_kind === undefined && payload.assetKind !== undefined) {
+    normalized.asset_kind = payload.assetKind
+  }
+
+  if (normalized.media_type === undefined && payload.mediaType !== undefined) {
+    normalized.media_type = payload.mediaType
+  }
+
+  if (normalized.storage_ref === undefined && payload.storageRef !== undefined) {
+    normalized.storage_ref = payload.storageRef
+  }
+
+  delete normalized.assetKind
+  delete normalized.mediaType
+  delete normalized.storageRef
+
+  return normalized
+}
+
+function normalizeInterpretationBuildPayload(payload = {}) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return payload
+  }
+
+  const normalized = { ...payload }
+  const partition =
+    normalized.partition && typeof normalized.partition === "object" && !Array.isArray(normalized.partition)
+      ? normalized.partition
+      : undefined
+  const subject =
+    normalized.subject && typeof normalized.subject === "object" && !Array.isArray(normalized.subject)
+      ? normalized.subject
+      : normalized.subjectRef && typeof normalized.subjectRef === "object" && !Array.isArray(normalized.subjectRef)
+        ? normalized.subjectRef
+        : undefined
+  const selection =
+    normalized.selection && typeof normalized.selection === "object" && !Array.isArray(normalized.selection)
+      ? normalized.selection
+      : undefined
+
+  const family =
+    selection?.family ??
+    partition?.family ??
+    (typeof normalized.family === "string" ? normalized.family : undefined)
+  const kind =
+    selection?.kind ??
+    partition?.kind ??
+    subject?.kind ??
+    (typeof normalized.kind === "string" ? normalized.kind : undefined)
+  const subjectId =
+    selection?.subject_id ??
+    subject?.id ??
+    subject?.subject_id ??
+    partition?.subject_id ??
+    partition?.segment
+  const subjectType =
+    selection?.subject_type ??
+    subject?.type ??
+    partition?.subject_type ??
+    (partition ? "market_segment" : undefined)
+  const subjectLabel =
+    selection?.subject_label ??
+    subject?.label ??
+    partition?.subject_label
+
+  if (
+    normalized.selection === undefined &&
+    typeof subjectId === "string" &&
+    subjectId.trim() !== ""
+  ) {
+    normalized.selection = compactObject({
+      family,
+      kind,
+      subject_type:
+        typeof subjectType === "string" && subjectType.trim() !== ""
+          ? subjectType.trim()
+          : undefined,
+      subject_id: subjectId.trim(),
+      subject_label:
+        typeof subjectLabel === "string" && subjectLabel.trim() !== ""
+          ? subjectLabel.trim()
+          : undefined,
+    })
+  }
+
+  if (normalized.subject === undefined && normalized.selection) {
+    normalized.subject = compactObject({
+      type: normalized.selection.subject_type,
+      id: normalized.selection.subject_id,
+      label: normalized.selection.subject_label,
+    })
+  }
+
+  if (normalized.partition === undefined && normalized.selection?.family) {
+    normalized.partition = compactObject({
+      family: normalized.selection.family,
+      segment: normalized.selection.subject_id,
+    })
+  }
+
+  delete normalized.subjectRef
+
+  return normalized
+}
+
+function looksLikePersonalDocumentRecord(value) {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      !Array.isArray(value) &&
+      (value.document_id !== undefined ||
+        value.documentId !== undefined ||
+        value.subspace !== undefined ||
+        value.body_markdown !== undefined ||
+        value.bodyMarkdown !== undefined),
+  )
+}
+
+function normalizePersonalDocumentRecord(record) {
+  if (!looksLikePersonalDocumentRecord(record)) {
+    return record
+  }
+
+  const normalized = { ...record }
+
+  if (normalized.document_id === undefined && record.documentId !== undefined) {
+    normalized.document_id = record.documentId
+  }
+
+  if (normalized.body_markdown === undefined && record.bodyMarkdown !== undefined) {
+    normalized.body_markdown = record.bodyMarkdown
+  }
+
+  if (normalized.asset_refs === undefined && record.assetRefs !== undefined) {
+    normalized.asset_refs = record.assetRefs
+  }
+
+  if (normalized.based_on === undefined && record.basedOn !== undefined) {
+    normalized.based_on = record.basedOn
+  }
+
+  if (normalized.source_document_ref === undefined && record.sourceDocumentRef !== undefined) {
+    normalized.source_document_ref = normalizeDocumentRefPayload(record.sourceDocumentRef)
+  }
+
+  if (normalized.workspace_path === undefined && record.workspacePath !== undefined) {
+    normalized.workspace_path = normalizeWorkspacePathPayload(record.workspacePath)
+  }
+
+  delete normalized.documentId
+  delete normalized.bodyMarkdown
+  delete normalized.assetRefs
+  delete normalized.basedOn
+  delete normalized.sourceDocumentRef
+  delete normalized.workspacePath
+
+  return normalized
+}
+
+function normalizePersonalDocumentResult(result) {
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return result
+  }
+
+  if (looksLikePersonalDocumentRecord(result)) {
+    return normalizePersonalDocumentRecord(result)
+  }
+
+  const normalized = { ...result }
+
+  if (Array.isArray(result.documents) && !Array.isArray(result.items)) {
+    normalized.items = result.documents.map(normalizePersonalDocumentRecord)
+  } else if (Array.isArray(result.items)) {
+    normalized.items = result.items.map(normalizePersonalDocumentRecord)
+  }
+
+  if (looksLikePersonalDocumentRecord(result.document)) {
+    normalized.document = normalizePersonalDocumentRecord(result.document)
+  } else if (looksLikePersonalDocumentRecord(result.record) && normalized.document === undefined) {
+    normalized.document = normalizePersonalDocumentRecord(result.record)
+  }
+
+  if (result.sourceDocumentRef !== undefined && normalized.source_document_ref === undefined) {
+    normalized.source_document_ref = normalizeDocumentRefPayload(result.sourceDocumentRef)
+  }
+
+  return normalized
+}
+
+function normalizeExplanationLayer(layer) {
+  return layer === "personal_raw" || layer === "personal_wiki" ? "personal" : layer
+}
+
 function formatOpportunityCursor(offset) {
   return `cursor_${String(offset).padStart(3, "0")}`
 }
@@ -381,7 +722,7 @@ export function createStratawikiHttpClient({
         },
         requestId,
       })
-      return response.result
+      return normalizePersonalDocumentResult(response.result)
     },
     async getPersonalDocument({ domain, tenantId, userId, documentId, requestId }) {
       const response = await request({
@@ -396,15 +737,16 @@ export function createStratawikiHttpClient({
         },
         requestId,
       })
-      return response.result
+      return normalizePersonalDocumentResult(response.result)
     },
     async createPersonalDocument({
       payload,
       requestId,
       idempotencyKey,
     }) {
-      const tenantId = requiredPayloadString(payload, "tenant_id")
-      const userId = requiredPayloadString(payload, "user_id")
+      const normalizedPayload = normalizePersonalDocumentPayload(payload)
+      const tenantId = requiredPayloadString(normalizedPayload, "tenant_id")
+      const userId = requiredPayloadString(normalizedPayload, "user_id")
       const response = await request({
         method: "POST",
         path: buildUserScopedPath({
@@ -412,11 +754,11 @@ export function createStratawikiHttpClient({
           userId,
           resourcePath: "personal-documents",
         }),
-        json: payload,
+        json: normalizedPayload,
         requestId,
         idempotencyKey,
       })
-      return response.result
+      return normalizePersonalDocumentResult(response.result)
     },
     async updatePersonalDocument({
       documentId,
@@ -424,8 +766,9 @@ export function createStratawikiHttpClient({
       requestId,
       idempotencyKey,
     }) {
-      const tenantId = requiredPayloadString(payload, "tenant_id")
-      const userId = requiredPayloadString(payload, "user_id")
+      const normalizedPayload = normalizePersonalDocumentPayload(payload)
+      const tenantId = requiredPayloadString(normalizedPayload, "tenant_id")
+      const userId = requiredPayloadString(normalizedPayload, "user_id")
       const response = await request({
         method: "PATCH",
         path: buildUserScopedPath({
@@ -433,11 +776,11 @@ export function createStratawikiHttpClient({
           userId,
           resourcePath: `personal-documents/${encodeURIComponent(documentId)}`,
         }),
-        json: payload,
+        json: normalizedPayload,
         requestId,
         idempotencyKey,
       })
-      return response.result
+      return normalizePersonalDocumentResult(response.result)
     },
     async deletePersonalDocument({
       documentId,
@@ -445,8 +788,9 @@ export function createStratawikiHttpClient({
       requestId,
       idempotencyKey,
     }) {
-      const tenantId = requiredPayloadString(payload, "tenant_id")
-      const userId = requiredPayloadString(payload, "user_id")
+      const normalizedPayload = normalizePersonalDocumentPayload(payload)
+      const tenantId = requiredPayloadString(normalizedPayload, "tenant_id")
+      const userId = requiredPayloadString(normalizedPayload, "user_id")
       const response = await request({
         method: "DELETE",
         path: buildUserScopedPath({
@@ -454,19 +798,20 @@ export function createStratawikiHttpClient({
           userId,
           resourcePath: `personal-documents/${encodeURIComponent(documentId)}`,
         }),
-        json: payload,
+        json: normalizedPayload,
         requestId,
         idempotencyKey,
       })
-      return response.result
+      return normalizePersonalDocumentResult(response.result)
     },
     async registerPersonalAsset({
       payload,
       requestId,
       idempotencyKey,
     }) {
-      const tenantId = requiredPayloadString(payload, "tenant_id")
-      const userId = requiredPayloadString(payload, "user_id")
+      const normalizedPayload = normalizePersonalAssetPayload(payload)
+      const tenantId = requiredPayloadString(normalizedPayload, "tenant_id")
+      const userId = requiredPayloadString(normalizedPayload, "user_id")
       const response = await request({
         method: "POST",
         path: buildUserScopedPath({
@@ -474,7 +819,7 @@ export function createStratawikiHttpClient({
           userId,
           resourcePath: "personal-assets",
         }),
-        json: payload,
+        json: normalizedPayload,
         requestId,
         idempotencyKey,
       })
@@ -485,9 +830,13 @@ export function createStratawikiHttpClient({
       requestId,
       idempotencyKey,
     }) {
-      const tenantId = requiredPayloadString(payload, "tenant_id")
-      const userId = requiredPayloadString(payload, "user_id")
-      const documentId = requiredPayloadString(payload?.source_document_ref, "document_id")
+      const normalizedPayload = normalizePersonalDocumentPayload(payload)
+      const tenantId = requiredPayloadString(normalizedPayload, "tenant_id")
+      const userId = requiredPayloadString(normalizedPayload, "user_id")
+      const documentId = requiredPayloadString(
+        normalizedPayload?.source_document_ref,
+        "document_id",
+      )
       const response = await request({
         method: "POST",
         path: buildUserScopedPath({
@@ -495,20 +844,24 @@ export function createStratawikiHttpClient({
           userId,
           resourcePath: `personal-documents/${encodeURIComponent(documentId)}/summarize-wiki`,
         }),
-        json: payload,
+        json: normalizedPayload,
         requestId,
         idempotencyKey,
       })
-      return response.result
+      return normalizePersonalDocumentResult(response.result)
     },
     async rewritePersonalDocumentToWiki({
       payload,
       requestId,
       idempotencyKey,
     }) {
-      const tenantId = requiredPayloadString(payload, "tenant_id")
-      const userId = requiredPayloadString(payload, "user_id")
-      const documentId = requiredPayloadString(payload?.source_document_ref, "document_id")
+      const normalizedPayload = normalizePersonalDocumentPayload(payload)
+      const tenantId = requiredPayloadString(normalizedPayload, "tenant_id")
+      const userId = requiredPayloadString(normalizedPayload, "user_id")
+      const documentId = requiredPayloadString(
+        normalizedPayload?.source_document_ref,
+        "document_id",
+      )
       const response = await request({
         method: "POST",
         path: buildUserScopedPath({
@@ -516,20 +869,24 @@ export function createStratawikiHttpClient({
           userId,
           resourcePath: `personal-documents/${encodeURIComponent(documentId)}/rewrite-wiki`,
         }),
-        json: payload,
+        json: normalizedPayload,
         requestId,
         idempotencyKey,
       })
-      return response.result
+      return normalizePersonalDocumentResult(response.result)
     },
     async structurePersonalDocumentToWiki({
       payload,
       requestId,
       idempotencyKey,
     }) {
-      const tenantId = requiredPayloadString(payload, "tenant_id")
-      const userId = requiredPayloadString(payload, "user_id")
-      const documentId = requiredPayloadString(payload?.source_document_ref, "document_id")
+      const normalizedPayload = normalizePersonalDocumentPayload(payload)
+      const tenantId = requiredPayloadString(normalizedPayload, "tenant_id")
+      const userId = requiredPayloadString(normalizedPayload, "user_id")
+      const documentId = requiredPayloadString(
+        normalizedPayload?.source_document_ref,
+        "document_id",
+      )
       const response = await request({
         method: "POST",
         path: buildUserScopedPath({
@@ -537,20 +894,21 @@ export function createStratawikiHttpClient({
           userId,
           resourcePath: `personal-documents/${encodeURIComponent(documentId)}/structure-wiki`,
         }),
-        json: payload,
+        json: normalizedPayload,
         requestId,
         idempotencyKey,
       })
-      return response.result
+      return normalizePersonalDocumentResult(response.result)
     },
     async suggestPersonalWikiLinks({
       payload,
       requestId,
       idempotencyKey,
     }) {
-      const tenantId = requiredPayloadString(payload, "tenant_id")
-      const userId = requiredPayloadString(payload, "user_id")
-      const documentId = requiredPayloadString(payload, "wiki_document_id")
+      const normalizedPayload = normalizePersonalDocumentPayload(payload)
+      const tenantId = requiredPayloadString(normalizedPayload, "tenant_id")
+      const userId = requiredPayloadString(normalizedPayload, "user_id")
+      const documentId = requiredPayloadString(normalizedPayload, "wiki_document_id")
       const response = await request({
         method: "POST",
         path: buildUserScopedPath({
@@ -558,7 +916,7 @@ export function createStratawikiHttpClient({
           userId,
           resourcePath: `personal-documents/${encodeURIComponent(documentId)}/suggest-links`,
         }),
-        json: payload,
+        json: normalizedPayload,
         requestId,
         idempotencyKey,
       })
@@ -569,9 +927,10 @@ export function createStratawikiHttpClient({
       requestId,
       idempotencyKey,
     }) {
-      const tenantId = requiredPayloadString(payload, "tenant_id")
-      const userId = requiredPayloadString(payload, "user_id")
-      const documentId = requiredPayloadString(payload, "wiki_document_id")
+      const normalizedPayload = normalizePersonalDocumentPayload(payload)
+      const tenantId = requiredPayloadString(normalizedPayload, "tenant_id")
+      const userId = requiredPayloadString(normalizedPayload, "user_id")
+      const documentId = requiredPayloadString(normalizedPayload, "wiki_document_id")
       const response = await request({
         method: "POST",
         path: buildUserScopedPath({
@@ -579,7 +938,7 @@ export function createStratawikiHttpClient({
           userId,
           resourcePath: `personal-documents/${encodeURIComponent(documentId)}/attach-links`,
         }),
-        json: payload,
+        json: normalizedPayload,
         requestId,
         idempotencyKey,
       })
@@ -646,10 +1005,11 @@ export function createStratawikiHttpClient({
       requestId,
       idempotencyKey,
     }) {
+      const normalizedPayload = normalizeInterpretationBuildPayload(payload)
       const response = await request({
         method: "POST",
         path: "/api/v1/interpretation-builds",
-        json: payload,
+        json: normalizedPayload,
         requestId,
         idempotencyKey,
       })
@@ -716,7 +1076,7 @@ export function createStratawikiHttpClient({
     async getExplanation({ domain, layer, recordId, tenantId, userId, requestId }) {
       const response = await request({
         method: "GET",
-        path: `/api/v1/explanations/${encodeURIComponent(layer)}/${encodeURIComponent(recordId)}`,
+        path: `/api/v1/explanations/${encodeURIComponent(normalizeExplanationLayer(layer))}/${encodeURIComponent(recordId)}`,
         query: {
           domain,
           tenant_id: tenantId,

--- a/packages/integrations/stratawiki-http/test/client.test.js
+++ b/packages/integrations/stratawiki-http/test/client.test.js
@@ -161,6 +161,100 @@ test("http client maps profile sync, personal query, and background build endpoi
   assert.equal(calls[2].method, "POST")
 })
 
+test("http client maps consumer-shaped read endpoints for workspace summary, opportunities, and calendar", async () => {
+  const calls = []
+  const client = createStratawikiHttpClient({
+    baseUrl: "http://127.0.0.1:8080",
+    requestIdFactory: () => "req-http-read-1",
+    fetchImpl: async (url, options) => {
+      calls.push({
+        url,
+        method: options.method,
+      })
+
+      if (url.includes("/api/v1/workspace-summary")) {
+        return createJsonResponse({
+          ok: true,
+          request_id: "req-http-read-1",
+          result: {
+            profileSnapshot: {
+              targetRole: "Profile profile_demo pending context hydration",
+            },
+          },
+        })
+      }
+
+      if (url.includes("/api/v1/opportunities/opp_abc")) {
+        return createJsonResponse({
+          ok: true,
+          request_id: "req-http-read-1",
+          result: {
+            opportunityId: "opp_abc",
+            title: "Backend Engineer",
+          },
+        })
+      }
+
+      if (url.includes("/api/v1/opportunities")) {
+        return createJsonResponse({
+          ok: true,
+          request_id: "req-http-read-1",
+          result: {
+            items: [{ opportunityId: "opp_abc" }],
+            nextCursor: "cursor_001",
+          },
+        })
+      }
+
+      return createJsonResponse({
+        ok: true,
+        request_id: "req-http-read-1",
+        result: {
+          items: [{ calendarItemId: "calendar_opp_abc" }],
+        },
+      })
+    },
+  })
+
+  const summary = await client.getWorkspaceSummary({
+    domain: "recruiting",
+    scope: "shared",
+    profileId: "profile_demo",
+  })
+  const list = await client.listOpportunities({
+    domain: "recruiting",
+    scope: "shared",
+    query: {
+      limit: 1,
+      cursorOffset: 1,
+      status: "open",
+    },
+  })
+  const detail = await client.getOpportunity({
+    domain: "recruiting",
+    scope: "shared",
+    opportunityId: "opp_abc",
+  })
+  const calendar = await client.getCalendar({
+    domain: "recruiting",
+    scope: "shared",
+    query: {
+      from: "2026-04-24",
+      to: "2026-04-30",
+    },
+  })
+
+  assert.equal(summary.profileSnapshot.targetRole, "Profile profile_demo pending context hydration")
+  assert.equal(list.items[0].opportunityId, "opp_abc")
+  assert.equal(list.nextCursor, "cursor_001")
+  assert.equal(detail.title, "Backend Engineer")
+  assert.equal(calendar.items[0].calendarItemId, "calendar_opp_abc")
+  assert.match(calls[0].url, /\/api\/v1\/workspace-summary\?domain=recruiting&scope=shared&profileId=profile_demo$/)
+  assert.match(calls[1].url, /\/api\/v1\/opportunities\?domain=recruiting&scope=shared&limit=1&cursor=cursor_001&status=open$/)
+  assert.match(calls[2].url, /\/api\/v1\/opportunities\/opp_abc\?domain=recruiting&scope=shared$/)
+  assert.match(calls[3].url, /\/api\/v1\/calendar\?domain=recruiting&scope=shared&from=2026-04-24&to=2026-04-30$/)
+})
+
 test("http client uses dedicated personal REST endpoints for document, asset, generation, and link flows", async () => {
   const calls = []
   const client = createStratawikiHttpClient({

--- a/packages/integrations/stratawiki-http/test/client.test.js
+++ b/packages/integrations/stratawiki-http/test/client.test.js
@@ -140,10 +140,12 @@ test("http client maps profile sync, personal query, and background build endpoi
   const build = await client.buildInterpretationSnapshot({
     payload: {
       domain: "recruiting",
-      partition: {
-        family: "market_trends",
-        segment: "backend-japan-midlevel",
+      subject: {
+        type: "market_segment",
+        id: "backend-japan-midlevel",
+        label: "Backend Japan Midlevel",
       },
+      family: "market_trends",
       fact_ids: ["fact:job:1"],
       fact_snapshot: "fact_snap:seed",
       model_profile: "balanced_default",
@@ -156,6 +158,16 @@ test("http client maps profile sync, personal query, and background build endpoi
   assert.equal(personal.answer_markdown, "## Strategy")
   assert.equal(build.job_id, "job-123")
   assert.equal(build.httpStatus, 202)
+  assert.deepEqual(calls[2].body.selection, {
+    family: "market_trends",
+    subject_type: "market_segment",
+    subject_id: "backend-japan-midlevel",
+    subject_label: "Backend Japan Midlevel",
+  })
+  assert.deepEqual(calls[2].body.partition, {
+    family: "market_trends",
+    segment: "backend-japan-midlevel",
+  })
   assert.equal(calls[0].method, "PUT")
   assert.equal(calls[1].method, "POST")
   assert.equal(calls[2].method, "POST")
@@ -289,85 +301,91 @@ test("http client uses dedicated personal REST endpoints for document, asset, ge
     domain: "recruiting",
     tenantId: "tenant-1",
     userId: "user-1",
-    documentId: "personal:1",
+    documentId: "pdoc_raw_1",
   })
   await client.createPersonalDocument({
     payload: {
       domain: "recruiting",
-      tenant_id: "tenant-1",
-      user_id: "user-1",
-      profile_version: "profile:v1",
+      tenantId: "tenant-1",
+      userId: "user-1",
+      profileVersion: "profile:v1",
       subspace: "raw",
       kind: "note",
       title: "Draft",
+      bodyMarkdown: "## Draft",
+      workspacePath: {
+        sectionId: "personal_raw",
+        segments: ["notes", "draft"],
+        label: "Draft",
+      },
     },
   })
   await client.updatePersonalDocument({
-    documentId: "personal:1",
+    documentId: "pdoc_raw_1",
     payload: {
       domain: "recruiting",
-      tenant_id: "tenant-1",
-      user_id: "user-1",
-      document_id: "personal:1",
-      profile_version: "profile:v1",
-      if_version: 1,
+      tenantId: "tenant-1",
+      userId: "user-1",
+      documentId: "pdoc_raw_1",
+      profileVersion: "profile:v1",
+      ifVersion: 1,
       title: "Draft v2",
     },
   })
   await client.deletePersonalDocument({
-    documentId: "personal:1",
+    documentId: "pdoc_raw_1",
     payload: {
       domain: "recruiting",
-      tenant_id: "tenant-1",
-      user_id: "user-1",
-      document_id: "personal:1",
-      if_version: 2,
+      tenantId: "tenant-1",
+      userId: "user-1",
+      documentId: "pdoc_raw_1",
+      ifVersion: 2,
     },
   })
   await client.registerPersonalAsset({
     payload: {
       domain: "recruiting",
-      tenant_id: "tenant-1",
-      user_id: "user-1",
-      asset_kind: "resume",
-      media_type: "application/pdf",
+      tenantId: "tenant-1",
+      userId: "user-1",
+      assetKind: "resume",
+      mediaType: "application/pdf",
       filename: "resume.pdf",
-      storage_ref: "s3://bucket/resume.pdf",
+      storageRef: "s3://bucket/resume.pdf",
     },
   })
   await client.summarizePersonalDocumentToWiki({
     payload: {
       domain: "recruiting",
-      tenant_id: "tenant-1",
-      user_id: "user-1",
-      source_document_ref: { document_id: "personal:1", subspace: "raw", version: 1 },
-      profile_version: "profile:v1",
+      tenantId: "tenant-1",
+      userId: "user-1",
+      sourceDocumentRef: { documentId: "pdoc_raw_1", subspace: "raw", version: 1 },
+      profileVersion: "profile:v1",
       model_profile: "balanced_default",
-      save_target: { subspace: "wiki" },
+      saveTarget: { subspace: "wiki" },
       summary_style: "brief",
     },
   })
   await client.rewritePersonalDocumentToWiki({
     payload: {
       domain: "recruiting",
-      tenant_id: "tenant-1",
-      user_id: "user-1",
-      source_document_ref: { document_id: "personal:1", subspace: "raw", version: 1 },
-      profile_version: "profile:v1",
+      tenantId: "tenant-1",
+      userId: "user-1",
+      sourceDocumentRef: { documentId: "pdoc_raw_1", subspace: "raw", version: 1 },
+      profileVersion: "profile:v1",
       model_profile: "balanced_default",
-      save_target: { subspace: "wiki" },
+      saveTarget: { subspace: "wiki" },
       rewrite_goal: "job-prep",
     },
   })
   await client.structurePersonalDocumentToWiki({
     payload: {
       domain: "recruiting",
-      tenant_id: "tenant-1",
-      user_id: "user-1",
-      source_document_ref: { document_id: "personal:1", subspace: "raw", version: 1 },
-      profile_version: "profile:v1",
+      tenantId: "tenant-1",
+      userId: "user-1",
+      sourceDocumentRef: { documentId: "pdoc_raw_1", subspace: "raw", version: 1 },
+      profileVersion: "profile:v1",
       model_profile: "balanced_default",
-      save_target: { subspace: "wiki" },
+      saveTarget: { subspace: "wiki" },
       structure_template: "job-brief",
     },
   })
@@ -376,7 +394,7 @@ test("http client uses dedicated personal REST endpoints for document, asset, ge
       domain: "recruiting",
       tenant_id: "tenant-1",
       user_id: "user-1",
-      wiki_document_id: "personal:2",
+      wiki_document_id: "pdoc_wiki_2",
       wiki_document_version: 1,
       profile_version: "profile:v1",
       model_profile: "balanced_default",
@@ -388,7 +406,7 @@ test("http client uses dedicated personal REST endpoints for document, asset, ge
       domain: "recruiting",
       tenant_id: "tenant-1",
       user_id: "user-1",
-      wiki_document_id: "personal:2",
+      wiki_document_id: "pdoc_wiki_2",
       wiki_document_version: 1,
       attachments: [{ layer: "fact", id: "fact:1" }],
     },
@@ -397,25 +415,31 @@ test("http client uses dedicated personal REST endpoints for document, asset, ge
   assert.equal(calls[0].method, "GET")
   assert.equal(calls[0].url, "http://127.0.0.1:8080/api/v1/users/tenant-1/user-1/personal-documents?domain=recruiting&subspace=raw&status=active&kind=note")
   assert.equal(calls[1].method, "GET")
-  assert.equal(calls[1].url, "http://127.0.0.1:8080/api/v1/users/tenant-1/user-1/personal-documents/personal%3A1?domain=recruiting")
+  assert.equal(calls[1].url, "http://127.0.0.1:8080/api/v1/users/tenant-1/user-1/personal-documents/pdoc_raw_1?domain=recruiting")
   assert.equal(calls[2].method, "POST")
   assert.equal(calls[2].url, "http://127.0.0.1:8080/api/v1/users/tenant-1/user-1/personal-documents")
+  assert.equal(calls[2].body.body_markdown, "## Draft")
+  assert.deepEqual(calls[2].body.workspace_path, {
+    section_id: "personal_raw",
+    segments: ["notes", "draft"],
+    label: "Draft",
+  })
   assert.equal(calls[3].method, "PATCH")
-  assert.equal(calls[3].url, "http://127.0.0.1:8080/api/v1/users/tenant-1/user-1/personal-documents/personal%3A1")
+  assert.equal(calls[3].url, "http://127.0.0.1:8080/api/v1/users/tenant-1/user-1/personal-documents/pdoc_raw_1")
   assert.equal(calls[4].method, "DELETE")
-  assert.equal(calls[4].url, "http://127.0.0.1:8080/api/v1/users/tenant-1/user-1/personal-documents/personal%3A1")
+  assert.equal(calls[4].url, "http://127.0.0.1:8080/api/v1/users/tenant-1/user-1/personal-documents/pdoc_raw_1")
   assert.equal(calls[5].method, "POST")
   assert.equal(calls[5].url, "http://127.0.0.1:8080/api/v1/users/tenant-1/user-1/personal-assets")
   assert.equal(calls[6].method, "POST")
-  assert.equal(calls[6].url, "http://127.0.0.1:8080/api/v1/users/tenant-1/user-1/personal-documents/personal%3A1/summarize-wiki")
+  assert.equal(calls[6].url, "http://127.0.0.1:8080/api/v1/users/tenant-1/user-1/personal-documents/pdoc_raw_1/summarize-wiki")
   assert.equal(calls[7].method, "POST")
-  assert.equal(calls[7].url, "http://127.0.0.1:8080/api/v1/users/tenant-1/user-1/personal-documents/personal%3A1/rewrite-wiki")
+  assert.equal(calls[7].url, "http://127.0.0.1:8080/api/v1/users/tenant-1/user-1/personal-documents/pdoc_raw_1/rewrite-wiki")
   assert.equal(calls[8].method, "POST")
-  assert.equal(calls[8].url, "http://127.0.0.1:8080/api/v1/users/tenant-1/user-1/personal-documents/personal%3A1/structure-wiki")
+  assert.equal(calls[8].url, "http://127.0.0.1:8080/api/v1/users/tenant-1/user-1/personal-documents/pdoc_raw_1/structure-wiki")
   assert.equal(calls[9].method, "POST")
-  assert.equal(calls[9].url, "http://127.0.0.1:8080/api/v1/users/tenant-1/user-1/personal-documents/personal%3A2/suggest-links")
+  assert.equal(calls[9].url, "http://127.0.0.1:8080/api/v1/users/tenant-1/user-1/personal-documents/pdoc_wiki_2/suggest-links")
   assert.equal(calls[10].method, "POST")
-  assert.equal(calls[10].url, "http://127.0.0.1:8080/api/v1/users/tenant-1/user-1/personal-documents/personal%3A2/attach-links")
+  assert.equal(calls[10].url, "http://127.0.0.1:8080/api/v1/users/tenant-1/user-1/personal-documents/pdoc_wiki_2/attach-links")
   assert.equal(calls[10].body.attachments[0].id, "fact:1")
 })
 
@@ -465,8 +489,8 @@ test("http client maps snapshot, cache, explanation, and tool-call reads", async
   })
   const explanation = await client.getExplanation({
     domain: "recruiting",
-    layer: "personal",
-    recordId: "personal:1",
+    layer: "personal_wiki",
+    recordId: "pdoc_wiki_1",
     tenantId: "tenant-1",
     userId: "user-1",
   })

--- a/scripts/cross-repo-http-smoke.mjs
+++ b/scripts/cross-repo-http-smoke.mjs
@@ -170,7 +170,7 @@ async function main() {
           batch: {
             batch_id: `cross-repo-http-smoke-${randomUUID().slice(0, 8)}`,
             domain: "recruiting",
-            pack_version: "2026-04-18",
+            pack_version: "2026-04-22",
             producer: "jobs-wiki-cross-repo-smoke",
             proposals: [],
           },

--- a/scripts/http-rest-smoke.mjs
+++ b/scripts/http-rest-smoke.mjs
@@ -39,7 +39,7 @@ function loadProposalBatch() {
     batch_id: batchId,
     domain: "recruiting",
     producer: "jobs-wiki-http-smoke",
-    pack_version: "2026-04-18",
+    pack_version: "2026-04-22",
     facts: [],
     relations: [],
   }

--- a/tests/domain-packs/fixtures/recruiting-golden-fixtures.json
+++ b/tests/domain-packs/fixtures/recruiting-golden-fixtures.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "recruiting-governance-fixtures/v1",
   "domain": "recruiting",
-  "packVersion": "2026-04-18",
+  "packVersion": "2026-04-22",
   "fixtures": [
     {
       "id": "worknet_open_recruitment_normal",

--- a/tests/domain-packs/fixtures/recruiting-invalid-proposal-batch.json
+++ b/tests/domain-packs/fixtures/recruiting-invalid-proposal-batch.json
@@ -1,7 +1,7 @@
 {
   "domain": "recruiting",
-  "packVersion": "2026-04-18",
-  "producer": "jobs-wiki.fixture.invalid/v1",
+  "packVersion": "2026-04-22",
+  "producer": "jobs-wiki.fixture.invalid/v2",
   "facts": [
     {
       "proposalId": "job_posting:worknet:EMP-INVALID",

--- a/tests/domain-packs/fixtures/worknet-open-recruitment-ambiguous-proposal-batch.json
+++ b/tests/domain-packs/fixtures/worknet-open-recruitment-ambiguous-proposal-batch.json
@@ -1,7 +1,7 @@
 {
   "domain": "recruiting",
-  "packVersion": "2026-04-18",
-  "producer": "jobs-wiki.worknet.open_recruitment.mapper/v1",
+  "packVersion": "2026-04-22",
+  "producer": "jobs-wiki.worknet.open_recruitment.mapper/v2",
   "facts": [
     {
       "proposalId": "job_posting:worknet:EMP-AMBIGUOUS-1",

--- a/tests/domain-packs/fixtures/worknet-open-recruitment-missing-company-proposal-batch.json
+++ b/tests/domain-packs/fixtures/worknet-open-recruitment-missing-company-proposal-batch.json
@@ -1,7 +1,7 @@
 {
   "domain": "recruiting",
-  "packVersion": "2026-04-18",
-  "producer": "jobs-wiki.worknet.open_recruitment.mapper/v1",
+  "packVersion": "2026-04-22",
+  "producer": "jobs-wiki.worknet.open_recruitment.mapper/v2",
   "facts": [
     {
       "proposalId": "job_posting:worknet:EMP-MISSING-COMPANY",

--- a/tests/domain-packs/fixtures/worknet-open-recruitment-missing-role-proposal-batch.json
+++ b/tests/domain-packs/fixtures/worknet-open-recruitment-missing-role-proposal-batch.json
@@ -1,7 +1,7 @@
 {
   "domain": "recruiting",
-  "packVersion": "2026-04-18",
-  "producer": "jobs-wiki.worknet.open_recruitment.mapper/v1",
+  "packVersion": "2026-04-22",
+  "producer": "jobs-wiki.worknet.open_recruitment.mapper/v2",
   "facts": [
     {
       "proposalId": "job_posting:worknet:EMP-MISSING-ROLE",

--- a/tests/domain-packs/fixtures/worknet-open-recruitment-proposal-batch.json
+++ b/tests/domain-packs/fixtures/worknet-open-recruitment-proposal-batch.json
@@ -1,7 +1,7 @@
 {
   "domain": "recruiting",
-  "packVersion": "2026-04-18",
-  "producer": "jobs-wiki.worknet.open_recruitment.mapper/v1",
+  "packVersion": "2026-04-22",
+  "producer": "jobs-wiki.worknet.open_recruitment.mapper/v2",
   "facts": [
     {
       "proposalId": "job_posting:worknet:EMP-1",

--- a/tests/domain-packs/recruiting-governance-fixtures.test.ts
+++ b/tests/domain-packs/recruiting-governance-fixtures.test.ts
@@ -108,7 +108,7 @@ const fixtureCatalog = await loadFixtureFile<RecruitingFixtureCatalog>(
   "recruiting-golden-fixtures.json",
 );
 const recruitingPack = await loadJsonFile<RecruitingPack>(
-  "packages/domain-packs/recruiting/v1.json",
+  "packages/domain-packs/recruiting/v2.json",
 );
 
 test("fixture catalog covers the core governance scenarios for recruiting", () => {

--- a/tests/domain-packs/recruiting-pack.test.mjs
+++ b/tests/domain-packs/recruiting-pack.test.mjs
@@ -5,19 +5,19 @@ import { resolve } from "node:path";
 
 const loadPack = async () =>
   JSON.parse(
-    await readFile(resolve("packages/domain-packs/recruiting/v1.json"), "utf8"),
+    await readFile(resolve("packages/domain-packs/recruiting/v2.json"), "utf8"),
   );
 
-test("recruiting pack v1 exposes the core recruiting entities and relations", async () => {
+test("recruiting pack v2 keeps the core recruiting entities and relations minimal", async () => {
   const pack = await loadPack();
 
   assert.equal(pack.manifest.domain, "recruiting");
-  assert.equal(pack.manifest.packVersion, "2026-04-18");
+  assert.equal(pack.manifest.packVersion, "2026-04-22");
   assert.deepEqual(Object.keys(pack.entityTypes).sort(), ["company", "job_posting", "role"]);
   assert.deepEqual(Object.keys(pack.relationTypes).sort(), ["for_role", "posted_by"]);
 });
 
-test("recruiting pack v1 keeps deferred candidates as posting attributes", async () => {
+test("recruiting pack v2 keeps deferred candidates as posting attributes", async () => {
   const pack = await loadPack();
   const postingAttributes = pack.entityTypes.job_posting.attributes;
 
@@ -29,7 +29,7 @@ test("recruiting pack v1 keeps deferred candidates as posting attributes", async
   assert.equal(pack.entityTypes.selection_step, undefined);
 });
 
-test("recruiting pack v1 defines identity hint fallback order for company and role", async () => {
+test("recruiting pack v2 defines identity hint fallback order for company and role", async () => {
   const pack = await loadPack();
 
   assert.deepEqual(
@@ -44,4 +44,23 @@ test("recruiting pack v1 defines identity hint fallback order for company and ro
     pack.entityTypes.job_posting.identity.strategies.map((strategy) => strategy.hint),
     ["source_id"],
   );
+});
+
+test("recruiting pack v2 defines interpretation taxonomy and source expansion policy", async () => {
+  const pack = await loadPack();
+
+  assert.equal(pack.interpretationGrammar.version, "recruiting-interpretation-grammar/v2");
+  assert.deepEqual(
+    Object.keys(pack.interpretationGrammar.families).sort(),
+    ["market_trends", "opportunity_landscape", "readiness_risks", "source_health"],
+  );
+  assert.equal(
+    pack.sourceExpansionPolicy.sourceFamilies["training.catalog"].role,
+    "supporting_interpretation_source",
+  );
+  assert.equal(
+    pack.sourceExpansionPolicy.sourceFamilies["news.article"].role,
+    "supporting_interpretation_source",
+  );
+  assert.equal(pack.evidencePolicy.familyRequirements.market_trends.minimumEvidenceItems, 2);
 });

--- a/tests/domain-packs/recruiting-proposal-mapper.test.ts
+++ b/tests/domain-packs/recruiting-proposal-mapper.test.ts
@@ -4,8 +4,8 @@ import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import {
   RECRUITING_PACK_VERSION,
-  WORKNET_RECRUITING_V1_AMBIGUOUS_FIELDS,
-  WORKNET_RECRUITING_V1_OMITTED_FIELDS,
+  WORKNET_RECRUITING_V2_AMBIGUOUS_FIELDS,
+  WORKNET_RECRUITING_V2_OMITTED_FIELDS,
   mapRecruitingSourceToDomainProposalBatch,
 } from "../../packages/domain-packs/recruiting/mapper.ts";
 import type { RecruitingSourcePayload } from "../../packages/integrations/worknet/src/recruiting.ts";
@@ -31,7 +31,7 @@ test("maps a normalized WorkNet recruiting payload to the recruiting proposal ba
   assert.deepEqual(actual, expected);
 });
 
-test("uses fallback identity hints and omits ambiguous v1-only fields", async () => {
+test("uses fallback identity hints and omits ambiguous v2 fields", async () => {
   const payload = await loadJsonFixture<RecruitingSourcePayload>(
     "worknet-open-recruitment-source.json",
   );
@@ -70,13 +70,13 @@ test("uses fallback identity hints and omits ambiguous v1-only fields", async ()
   assert.equal("required_documents" in posting.attributes, false);
   assert.equal("inquiry" in posting.attributes, false);
   assert.equal("notes" in posting.attributes, false);
-  assert.deepEqual(WORKNET_RECRUITING_V1_AMBIGUOUS_FIELDS, ["posting.notes"]);
-  assert.ok(WORKNET_RECRUITING_V1_OMITTED_FIELDS.includes("attachments[]"));
+  assert.deepEqual(WORKNET_RECRUITING_V2_AMBIGUOUS_FIELDS, ["posting.notes"]);
+  assert.ok(WORKNET_RECRUITING_V2_OMITTED_FIELDS.includes("attachments[]"));
 });
 
 test("keeps the mapper pack version aligned with the recruiting pack artifact", async () => {
   const pack = await loadJsonFile<{ manifest: { packVersion: string } }>(
-    "packages/domain-packs/recruiting/v1.json",
+    "packages/domain-packs/recruiting/v2.json",
   );
 
   assert.equal(RECRUITING_PACK_VERSION, pack.manifest.packVersion);


### PR DESCRIPTION
## What changed
- aligned the root Jobs-Wiki docs with the current workspace-first PKM MVP baseline
- clarified doc precedence between the root README, `docs/README.md`, and the StrataWiki integration doc
- fixed WAS real-mode adapter initialization so missing StrataWiki HTTP configuration stays on the normalized retryable 503 path
- made the affected app tests deterministic by preventing ambient local `.env` values from changing the intended missing-base-url behavior

## Why it changed
The repo had two kinds of drift at once:
1. product/baseline wording in the root docs no longer matched the current `docs/` source of truth
2. WAS real-mode tests depended on eager StrataWiki client construction plus local environment leakage, which broke the expected fallback contract

This PR brings the docs and runtime behavior back into alignment with the current baseline.

## Impact
- readers now see the correct workspace-first baseline and doc authority map
- integration expectations are clearer: HTTP-first is the current baseline, SQL read fallback is deprecated compatibility behavior
- real-mode WAS endpoints now fail in a stable, normalized way when StrataWiki HTTP base URL configuration is absent

## Root cause
- stale root-level wording preserved an older report-first framing after the product baseline had shifted under `docs/`
- eager personal-knowledge client construction turned configuration gaps into startup-time failures and let local `.env` state interfere with tests that were meant to validate missing-config behavior

## Validation
- `npm --prefix Jobs-Wiki/apps/was run test -- --test-name-pattern "real command facade mode returns normalized temporary unavailability errors for command status|real adapter mode returns normalized temporary unavailability errors|real document detail mode returns normalized temporary unavailability errors|personal knowledge client rejects legacy non-http integration modes"`
- `npm --prefix Jobs-Wiki run verify:mvp`
