### PR TITLE
[codex] Align fixture copy with the workspace-first baseline

### DIFF
--- a/apps/was/src/fixtures/opportunities.fixture.js
+++ b/apps/was/src/fixtures/opportunities.fixture.js
@@ -5,7 +5,7 @@ export const opportunityListFixture = [
     title: "Backend Platform Engineer",
     companyName: "Northstar Data",
     roleLabels: ["Backend", "Platform"],
-    summary: "Build internal API platform and developer tooling for a report-first product.",
+    summary: "Build internal API platform and developer tooling for a workspace-first product.",
     employmentType: "full_time",
     opensAt: "2026-04-01T09:00:00+09:00",
     closesAt: "2026-05-01T23:59:59+09:00",
@@ -56,7 +56,7 @@ export const opportunityDetailsFixture = {
     title: "Backend Platform Engineer",
     summary: "Build API surfaces for hiring intelligence products.",
     descriptionMarkdown:
-      "Lead the WAS layer for report-first workflows, API composition, and adapter boundaries.",
+      "Lead the WAS layer for workspace-first workflows, API composition, and adapter boundaries.",
     employmentType: "full_time",
     opensAt: "2026-04-01T09:00:00+09:00",
     closesAt: "2026-05-01T23:59:59+09:00",


### PR DESCRIPTION
## What changed
- updated the remaining stale `report-first` wording in the WAS opportunity fixture
- aligned mock summary and detail copy with the current workspace-first baseline

## Why it changed
The previous baseline-alignment PR cleaned up the authoritative docs and runtime fallback behavior, but two mock payload strings still used the older report-first framing. Leaving them in place would keep avoidable drift in sample WAS responses and tests.

## Impact
- mock/sample WAS opportunity payloads now use the same workspace-first framing as the current product baseline
- no runtime behavior or contracts changed

## Root cause
The earlier cleanup addressed the authoritative docs and adapter behavior first; fixture copy was a smaller leftover drift item.

## Validation
- `npm --prefix Jobs-Wiki run verify:mvp`
